### PR TITLE
Feature/phone call muting

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
 
     <application
         android:name="live.hms.app2.ui.GlobalApplication"

--- a/app/src/main/java/live/hms/app2/helpers/PhoneCallEvents.kt
+++ b/app/src/main/java/live/hms/app2/helpers/PhoneCallEvents.kt
@@ -1,0 +1,63 @@
+package live.hms.app2.helpers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.telephony.TelephonyManager
+import android.util.Log
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.flow.callbackFlow
+
+sealed class PhoneCallEvents {
+    object MUTE_ALL : PhoneCallEvents()
+    object UNMUTE_ALL : PhoneCallEvents()
+}
+
+/**
+ * Emits events for whether the calls should be muted:
+ *  1. Mute when a call is received or in the process of dialling.
+ *  2. Unmute when a call is terminated.
+ *
+ *  The events will be used to determine that the video/mic should be turned off.
+ *  Collecting this flow will register the receiver.
+ */
+@ExperimentalCoroutinesApi
+fun getPhoneStateFlow(context: Context) = callbackFlow {
+
+    // Create phone call broadcast receivers
+    val regularPhoneCallReceiver: BroadcastReceiver = PhoneCallMonitor { event -> sendBlocking(event) }
+    val phoneCallIntentFilter = IntentFilter(TelephonyManager.ACTION_PHONE_STATE_CHANGED)
+
+    // Register phone receiver when the flow starts (consider shareIn so it's not duplicated)
+    context.registerReceiver(regularPhoneCallReceiver, phoneCallIntentFilter)
+
+    // Unregister receivers when the flow is closed.
+    awaitClose {
+        context.unregisterReceiver(regularPhoneCallReceiver)
+    }
+}
+
+/**
+ * A broadcast receiver that converts phone events
+ * to events saying whether we should mute or not.
+ */
+private class PhoneCallMonitor(private val onEvent: (PhoneCallEvents) -> Unit) :
+    BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        Log.d("Call", "intent?.action")
+
+        when (intent?.getStringExtra(TelephonyManager.EXTRA_STATE)) {
+            TelephonyManager.EXTRA_STATE_IDLE -> onEvent(PhoneCallEvents.UNMUTE_ALL)
+            TelephonyManager.EXTRA_STATE_OFFHOOK,
+            TelephonyManager.EXTRA_STATE_RINGING -> onEvent(PhoneCallEvents.MUTE_ALL)
+            else -> {
+                /** Ignore **/
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/live/hms/app2/ui/home/permission/PermissionFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/home/permission/PermissionFragment.kt
@@ -22,7 +22,7 @@ class PermissionFragment : Fragment(), EasyPermissions.PermissionCallbacks {
     private const val TAG = "PermissionFragment"
 
     private const val RC_CALL = 111
-    private val PERMISSIONS = arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
+    private val PERMISSIONS = arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO, Manifest.permission.READ_PHONE_STATE)
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/live/hms/app2/ui/meeting/ILocalMediaControl.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/ILocalMediaControl.kt
@@ -1,0 +1,8 @@
+package live.hms.app2.ui.meeting
+
+interface ILocalMediaControl {
+    fun isLocalAudioEnabled() : Boolean?
+    fun isLocalVideoEnabled() :  Boolean?
+    fun setLocalAudioEnabled(enabled : Boolean)
+    fun setLocalVideoEnabled(enabled : Boolean)
+}

--- a/app/src/main/java/live/hms/app2/ui/meeting/IPeerMediaControl.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/IPeerMediaControl.kt
@@ -1,0 +1,6 @@
+package live.hms.app2.ui.meeting
+
+interface IPeerMediaControl {
+    fun isPeerAudioEnabled() : Boolean?
+    fun setPeerAudioEnabled(enabled : Boolean)
+}

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingFragment.kt
@@ -10,6 +10,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Observer
 import androidx.lifecycle.observe
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
@@ -134,10 +135,10 @@ class MeetingFragment : Fragment() {
 
   private fun updateActionVolumeMenuIcon(item: MenuItem) {
     item.apply {
-      if (meetingViewModel.isAudioMuted) {
-        setIcon(R.drawable.ic_volume_off_24)
-      } else {
+      if (meetingViewModel.isPeerAudioEnabled()) {
         setIcon(R.drawable.ic_volume_up_24)
+      } else {
+        setIcon(R.drawable.ic_volume_off_24)
       }
     }
   }
@@ -175,6 +176,7 @@ class MeetingFragment : Fragment() {
     super.onViewCreated(view, savedInstanceState)
     initViewModel()
     setHasOptionsMenu(true)
+    meetingViewModel.showAudioMuted.observe(viewLifecycleOwner, Observer { activity?.invalidateOptionsMenu() })
   }
 
   override fun onCreateView(

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -160,7 +160,7 @@ class MeetingViewModel(
     }
   }
 
-  override fun isLocalVideoEnabled() : Boolean? = localVideoTrack?.isMute
+  override fun isLocalVideoEnabled() : Boolean? = localVideoTrack?.isMute?.not()
 
   fun toggleLocalVideo() {
       localVideoTrack?.let { setLocalVideoEnabled(it.isMute) }
@@ -180,7 +180,7 @@ class MeetingViewModel(
   }
 
   override fun isLocalAudioEnabled() : Boolean? {
-    return localAudioTrack?.isMute
+    return localAudioTrack?.isMute?.not()
   }
 
   fun toggleLocalAudio() {

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -80,8 +80,11 @@ class MeetingViewModel(
     this.title.postValue(resId)
   }
 
+  var showAudioMuted = MutableLiveData(false)
+    private set
+
   // Flag to keep track whether the incoming audio need's to be muted
-  var isAudioMuted: Boolean = false
+  private var isAudioMuted: Boolean = false
     set(value) {
       synchronized(_tracks) {
         field = value
@@ -94,6 +97,7 @@ class MeetingViewModel(
             }
           }
         }
+        showAudioMuted.postValue(value)
       }
     }
 
@@ -184,17 +188,17 @@ class MeetingViewModel(
     localAudioTrack?.let { setLocalAudioEnabled(it.isMute) }
   }
 
-  override fun isPeerAudioEnabled() : Boolean = isAudioMuted
+  override fun isPeerAudioEnabled() : Boolean = !isAudioMuted
 
   /**
    * Helper function to toggle others audio tracks
    */
   fun toggleAudio() {
-    setPeerAudioEnabled(!isAudioMuted)
+    setPeerAudioEnabled(isAudioMuted)
   }
 
   override fun setPeerAudioEnabled(enabled : Boolean) {
-    isAudioMuted = enabled
+    isAudioMuted = !enabled
   }
 
   fun sendChatMessage(message: String) {

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -133,35 +133,58 @@ class MeetingViewModel(
     hmsSDK.preview(config, listener)
   }
 
-  fun toggleLocalVideo() {
+  private fun setLocalVideoEnabled(enabled : Boolean) {
+
     localVideoTrack?.apply {
-      val isVideo = !isMute
-      setMute(isVideo)
+
+      setMute(!enabled)
 
       tracks.postValue(_tracks)
 
-      isLocalVideoEnabled.postValue(!isVideo)
-      crashlyticsLog(TAG, "toggleUserVideo: enabled=$isVideo")
+      isLocalVideoEnabled.postValue(enabled)
+      crashlyticsLog(TAG, "toggleUserVideo: enabled=$enabled")
     }
+  }
+
+  private fun isLocalVideoEnabled() : Boolean? = localVideoTrack?.isMute
+
+  fun toggleLocalVideo() {
+      localVideoTrack?.let { setLocalVideoEnabled(it.isMute) }
+  }
+
+  private fun setLocalAudioEnabled(enabled: Boolean) {
+
+    localAudioTrack?.apply {
+      setMute(!enabled)
+
+      tracks.postValue(_tracks)
+
+      isLocalAudioEnabled.postValue(enabled)
+      crashlyticsLog(TAG, "toggleUserMic: enabled=$enabled")
+    }
+
+  }
+
+  private fun isLocalAudioEnabled() : Boolean? {
+    return localAudioTrack?.isMute
   }
 
   fun toggleLocalAudio() {
-    localAudioTrack?.apply {
-      val isAudio = !isMute
-      setMute(isAudio)
-
-      tracks.postValue(_tracks)
-
-      isLocalAudioEnabled.postValue(!isAudio)
-      crashlyticsLog(TAG, "toggleUserMic: enabled=$isAudio")
-    }
+    // If mute then enable audio, if not mute, disable it
+    localAudioTrack?.let { setLocalAudioEnabled(it.isMute) }
   }
+
+  private fun isPeerAudioEnabled() : Boolean = isAudioMuted
 
   /**
    * Helper function to toggle others audio tracks
    */
   fun toggleAudio() {
-    isAudioMuted = !isAudioMuted
+    setAudioEnabled(!isAudioMuted)
+  }
+
+  private fun setAudioEnabled(enabled : Boolean) {
+    isAudioMuted = enabled
   }
 
   fun sendChatMessage(message: String) {

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -30,7 +30,7 @@ import kotlin.collections.ArrayList
 class MeetingViewModel(
   application: Application,
   private val roomDetails: RoomDetails
-) : AndroidViewModel(application) {
+) : AndroidViewModel(application), IPeerMediaControl, ILocalMediaControl {
   companion object {
     private const val TAG = "MeetingViewModel"
   }
@@ -53,15 +53,8 @@ class MeetingViewModel(
     viewModelScope.launch {
 
       // TODO possibly consider an interface for is/set audio and video
-      PhoneMutingUseCase().init(getApplication<Application>(),
-        ::isLocalAudioEnabled,
-        ::isLocalVideoEnabled,
-        ::isPeerAudioEnabled,
-
-        ::setLocalAudioEnabled,
-        ::setLocalVideoEnabled,
-        ::setAudioEnabled
-      ).collect()
+      PhoneMutingUseCase().execute(getApplication<Application>(),
+        this@MeetingViewModel, this@MeetingViewModel).collect()
     }
   }
 
@@ -150,7 +143,7 @@ class MeetingViewModel(
     hmsSDK.preview(config, listener)
   }
 
-  private fun setLocalVideoEnabled(enabled : Boolean) {
+  override fun setLocalVideoEnabled(enabled : Boolean) {
 
     localVideoTrack?.apply {
 
@@ -163,13 +156,13 @@ class MeetingViewModel(
     }
   }
 
-  private fun isLocalVideoEnabled() : Boolean? = localVideoTrack?.isMute
+  override fun isLocalVideoEnabled() : Boolean? = localVideoTrack?.isMute
 
   fun toggleLocalVideo() {
       localVideoTrack?.let { setLocalVideoEnabled(it.isMute) }
   }
 
-  private fun setLocalAudioEnabled(enabled: Boolean) {
+  override fun setLocalAudioEnabled(enabled: Boolean) {
 
     localAudioTrack?.apply {
       setMute(!enabled)
@@ -182,7 +175,7 @@ class MeetingViewModel(
 
   }
 
-  private fun isLocalAudioEnabled() : Boolean? {
+  override fun isLocalAudioEnabled() : Boolean? {
     return localAudioTrack?.isMute
   }
 
@@ -191,16 +184,16 @@ class MeetingViewModel(
     localAudioTrack?.let { setLocalAudioEnabled(it.isMute) }
   }
 
-  private fun isPeerAudioEnabled() : Boolean = isAudioMuted
+  override fun isPeerAudioEnabled() : Boolean = isAudioMuted
 
   /**
    * Helper function to toggle others audio tracks
    */
   fun toggleAudio() {
-    setAudioEnabled(!isAudioMuted)
+    setPeerAudioEnabled(!isAudioMuted)
   }
 
-  private fun setAudioEnabled(enabled : Boolean) {
+  override fun setPeerAudioEnabled(enabled : Boolean) {
     isAudioMuted = enabled
   }
 

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -5,7 +5,9 @@ import android.util.Log
 import androidx.annotation.StringRes
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import com.google.gson.JsonObject
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import live.hms.app2.model.RoomDetails
 import live.hms.app2.ui.meeting.chat.ChatMessage
@@ -47,7 +49,22 @@ class MeetingViewModel(
       crashlytics.setCustomKey(ENVIRONMENT, env)
       crashlytics.setCustomKey(AUTH_TOKEN, authToken)
     }
+
+    viewModelScope.launch {
+
+      // TODO possibly consider an interface for is/set audio and video
+      PhoneMutingUseCase().init(getApplication<Application>(),
+        ::isLocalAudioEnabled,
+        ::isLocalVideoEnabled,
+        ::isPeerAudioEnabled,
+
+        ::setLocalAudioEnabled,
+        ::setLocalVideoEnabled,
+        ::setAudioEnabled
+      ).collect()
+    }
   }
+
 
   private val _tracks = Collections.synchronizedList(ArrayList<MeetingTrack>())
 

--- a/app/src/main/java/live/hms/app2/ui/meeting/PhoneMutingUseCase.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/PhoneMutingUseCase.kt
@@ -27,18 +27,19 @@ class PhoneMutingUseCase {
             when (phoneInterruptEvents) {
 
                 PhoneCallEvents.MUTE_ALL -> {
+                    // Store all the existing states of peer volume, local audio and video
+                    //  when we restore it on unmuting it should get the original values back.
+                    //  note we aren't taking into account any values that were modified in the interim.
                     prevLocalAudioState = localMc.isLocalAudioEnabled()
                     prevLocalVideoState = localMc.isLocalVideoEnabled()
                     prevPeerAudioState = peerMc.isPeerAudioEnabled()
-                    Log.d("PhoneMutingUseCase","Muting: $prevLocalVideoState $prevLocalAudioState $prevPeerAudioState")
                     localMc.setLocalAudioEnabled(false)
                     localMc.setLocalVideoEnabled(false)
                     peerMc.setPeerAudioEnabled(false)
                 }
 
                 PhoneCallEvents.UNMUTE_ALL -> {
-                    Log.d("PhoneMutingUseCase","Un: $prevLocalVideoState $prevLocalAudioState $prevPeerAudioState")
-                    // Restore the previous states
+                    // Restore the previous states of audio, video and peer volume
                     prevLocalAudioState?.let {
                         localMc.setLocalAudioEnabled(it)
                     }

--- a/app/src/main/java/live/hms/app2/ui/meeting/PhoneMutingUseCase.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/PhoneMutingUseCase.kt
@@ -38,19 +38,16 @@ class PhoneMutingUseCase {
 
                 PhoneCallEvents.UNMUTE_ALL -> {
                     Log.d("PhoneMutingUseCase","Un: $prevLocalVideoState $prevLocalAudioState $prevPeerAudioState")
-                    localMc.setLocalAudioEnabled(true)
-                    localMc.setLocalVideoEnabled(true)
-                    peerMc.setPeerAudioEnabled(true)
-                    // TODO we should really restore people's state, not blank turn on.
-//                    prevLocalAudioState?.let {
-//                        setLocalAudio(it)
-//                    }
-//                    prevLocalVideoState?.let{
-//                        setLocalVideo(it)
-//                    }
-//                    prevPeerAudioState?.let {
-//                        setPeerAudio(it)
-//                    }
+                    // Restore the previous states
+                    prevLocalAudioState?.let {
+                        localMc.setLocalAudioEnabled(it)
+                    }
+                    prevLocalVideoState?.let{
+                        localMc.setLocalVideoEnabled(it)
+                    }
+                    prevPeerAudioState?.let {
+                        peerMc.setPeerAudioEnabled(it)
+                    }
                 }
             }
         }

--- a/app/src/main/java/live/hms/app2/ui/meeting/PhoneMutingUseCase.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/PhoneMutingUseCase.kt
@@ -1,0 +1,62 @@
+package live.hms.app2.ui.meeting
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
+import live.hms.app2.helpers.PhoneCallEvents
+import live.hms.app2.helpers.getPhoneStateFlow
+
+/**
+ * Logic that takes mute events emitted
+ *  uses them to actually call the mute methods on the sdk.
+ */
+class PhoneMutingUseCase {
+    /* Stores whether the user had their local audio/video on
+     * this should be restored when the call ends.
+     */
+    private var prevLocalAudioState : Boolean? = null
+    private var prevLocalVideoState : Boolean? = null
+    private var prevPeerAudioState : Boolean? = null
+
+    fun init(context: Context,
+             getLocalAudioEnabled : () -> Boolean?,
+             getLocalVideoEnabled : () -> Boolean?,
+             getPeerAudioEnabled : () -> Boolean?,
+             setLocalAudio : (Boolean) -> Unit,
+             setLocalVideo : (Boolean) -> Unit,
+             setPeerAudio : (Boolean) -> Unit ): Flow<PhoneCallEvents> {
+
+        return getPhoneStateFlow(context).onEach { phoneInterruptEvents ->
+            when (phoneInterruptEvents) {
+
+                PhoneCallEvents.MUTE_ALL -> {
+                    prevLocalAudioState = getLocalAudioEnabled()
+                    prevLocalVideoState = getLocalVideoEnabled()
+                    prevPeerAudioState = getPeerAudioEnabled()
+                    Log.d("PhoneMutingUseCase","Muting: $prevLocalVideoState $prevLocalAudioState $prevPeerAudioState")
+                    setLocalAudio(false)
+                    setLocalVideo(false)
+                    setPeerAudio(false)
+                }
+
+                PhoneCallEvents.UNMUTE_ALL -> {
+                    Log.d("PhoneMutingUseCase","Un: $prevLocalVideoState $prevLocalAudioState $prevPeerAudioState")
+                    setLocalAudio(true)
+                    setLocalVideo(true)
+                    setPeerAudio(true)
+                    // TODO we should really restore people's state, not blank turn on.
+//                    prevLocalAudioState?.let {
+//                        setLocalAudio(it)
+//                    }
+//                    prevLocalVideoState?.let{
+//                        setLocalVideo(it)
+//                    }
+//                    prevPeerAudioState?.let {
+//                        setPeerAudio(it)
+//                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/live/hms/app2/ui/meeting/PhoneMutingUseCase.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/PhoneMutingUseCase.kt
@@ -19,32 +19,28 @@ class PhoneMutingUseCase {
     private var prevLocalVideoState : Boolean? = null
     private var prevPeerAudioState : Boolean? = null
 
-    fun init(context: Context,
-             getLocalAudioEnabled : () -> Boolean?,
-             getLocalVideoEnabled : () -> Boolean?,
-             getPeerAudioEnabled : () -> Boolean?,
-             setLocalAudio : (Boolean) -> Unit,
-             setLocalVideo : (Boolean) -> Unit,
-             setPeerAudio : (Boolean) -> Unit ): Flow<PhoneCallEvents> {
+    fun execute(context: Context,
+                localMc: ILocalMediaControl,
+                peerMc: IPeerMediaControl): Flow<PhoneCallEvents> {
 
         return getPhoneStateFlow(context).onEach { phoneInterruptEvents ->
             when (phoneInterruptEvents) {
 
                 PhoneCallEvents.MUTE_ALL -> {
-                    prevLocalAudioState = getLocalAudioEnabled()
-                    prevLocalVideoState = getLocalVideoEnabled()
-                    prevPeerAudioState = getPeerAudioEnabled()
+                    prevLocalAudioState = localMc.isLocalAudioEnabled()
+                    prevLocalVideoState = localMc.isLocalVideoEnabled()
+                    prevPeerAudioState = peerMc.isPeerAudioEnabled()
                     Log.d("PhoneMutingUseCase","Muting: $prevLocalVideoState $prevLocalAudioState $prevPeerAudioState")
-                    setLocalAudio(false)
-                    setLocalVideo(false)
-                    setPeerAudio(false)
+                    localMc.setLocalAudioEnabled(false)
+                    localMc.setLocalVideoEnabled(false)
+                    peerMc.setPeerAudioEnabled(false)
                 }
 
                 PhoneCallEvents.UNMUTE_ALL -> {
                     Log.d("PhoneMutingUseCase","Un: $prevLocalVideoState $prevLocalAudioState $prevPeerAudioState")
-                    setLocalAudio(true)
-                    setLocalVideo(true)
-                    setPeerAudio(true)
+                    localMc.setLocalAudioEnabled(true)
+                    localMc.setLocalVideoEnabled(true)
+                    peerMc.setPeerAudioEnabled(true)
                     // TODO we should really restore people's state, not blank turn on.
 //                    prevLocalAudioState?.let {
 //                        setLocalAudio(it)

--- a/app/src/main/java/live/hms/app2/ui/meeting/PreviewFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/PreviewFragment.kt
@@ -168,10 +168,10 @@ class PreviewFragment : Fragment() {
 
   private fun updateActionVolumeMenuIcon(item: MenuItem) {
     item.apply {
-      if (meetingViewModel.isAudioMuted) {
-        setIcon(R.drawable.ic_volume_off_24)
-      } else {
+      if (meetingViewModel.isPeerAudioEnabled()) {
         setIcon(R.drawable.ic_volume_up_24)
+      } else {
+        setIcon(R.drawable.ic_volume_off_24)
       }
     }
   }


### PR DESCRIPTION
This solves [HMS-2839](https://100ms.atlassian.net/browse/HMS-2839).
Phone calls now mute audio/video/speaker.
The updates can be seen on web and mobile.

Note, whatsapp/zoom items need to be done within the SDK only as per previous discussion. Those changes are not included here.

Changes were made in three major files.
Existing: MeetingViewModel
New: PhoneCallEvents, PhoneMutingUseCase

In broad terms, the PhoneCallEvents exposes a function that creates a Flow. The flow abstracts away events from the BroadcastReceiver and is written in such a way that multiple sources can go into it in the future.
The PhoneMutingUseCase is where the logic for the muting/unmuting feature is contained so that to apply this, the viewmodel only has to collect the flow and pass in the getters/setters, keeping it clean.

**MeetingViewModel**
The only change in the viewmodel is that methods are added for getting and setting local audio, video and speaker.
The PhoneMutingUseCase is launched in init (note this affects the preview too, whether this is desired or not depends).
All logic for the feature is contained within PhoneMutingUseCase, keeping it from adding to the LOC of MeetingViewModel.

It keeps track of the states as they were just before it mutes them and then restores them on unmute.
Implementation details:
The getPhoneStateFlow method in [PhoneCallEvents](src/main/java/live/hms/app2/helpers/PhoneCallEvents.kt) converts a BroadcastReceiver for PhoneState events into emitted items in a flow for mute and unmute events.

The only purpose of the function is to convert intents from a receiver into `Flow<PhoneCallEvents>` where PhoneCallEvents are:
`
sealed class PhoneCallEvents {
    object MUTE_ALL : PhoneCallEvents()
    object UNMUTE_ALL : PhoneCallEvents()
}`

It also handles registering the receiver only when the Flow is collected, and unregisters the receiver when Flow's closed.

**Next: PhoneMutingUseCase**
The PhoneMutingUseCase is what takes the emitted events and acts on the ViewModel. The ViewModel now implements two interfaces, one to get and set local audio/video and one to get and set speaker states.
The use case preserves the previous values of these within itself when a mute event is emitted and restores them when an unmute event is emitted.


**Minor changes**
Were made in the fragments to make the speaker menu item update (by invalidating the menu when the speaker livedata changes.