### PR TITLE
Bugfix/change role settings

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -480,6 +480,8 @@ class MeetingViewModel(
     if( remotePeer != null && toRole != null) {
       if (remotePeer.hmsRole.name != toRole.name)
         hmsSDK.changeRole(remotePeer, toRole, force)
+      // Update the peer in participants
+        peerLiveDate.postValue(remotePeer)
       }
   }
 }

--- a/app/src/main/java/live/hms/app2/ui/meeting/participants/BottomSheetRoleChangeFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/participants/BottomSheetRoleChangeFragment.kt
@@ -7,16 +7,15 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
+import android.widget.Spinner
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import live.hms.app2.R
-import live.hms.app2.databinding.FragmentParticipantsBinding
 import live.hms.app2.databinding.LayoutFragmentBottomSheetChangeRoleBinding
 import live.hms.app2.ui.meeting.MeetingViewModel
 import live.hms.app2.util.viewLifecycle
-import android.widget.Spinner
-import androidx.navigation.fragment.navArgs
 
 
 class BottomSheetRoleChangeFragment : BottomSheetDialogFragment(), AdapterView.OnItemSelectedListener {
@@ -27,6 +26,7 @@ class BottomSheetRoleChangeFragment : BottomSheetDialogFragment(), AdapterView.O
 
     private var binding by viewLifecycle<LayoutFragmentBottomSheetChangeRoleBinding>()
     private lateinit var popupSpinner : Spinner
+    private val spinnerRoles by lazy { args.availableRoles.plus("Cancel") }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -49,10 +49,11 @@ class BottomSheetRoleChangeFragment : BottomSheetDialogFragment(), AdapterView.O
         ArrayAdapter(
             requireActivity(),
             android.R.layout.simple_list_item_1,
-            args.availableRoles
+            spinnerRoles
         ).also { arrayAdapter ->
             popupSpinner.adapter = arrayAdapter
             popupSpinner.prompt = "Role Change Request"
+            popupSpinner.setSelection(spinnerRoles.size - 1, false)
             arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
             popupSpinner.post { popupSpinner.onItemSelectedListener = this }
         }

--- a/app/src/main/java/live/hms/app2/ui/meeting/participants/BottomSheetRoleChangeFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/participants/BottomSheetRoleChangeFragment.kt
@@ -53,9 +53,8 @@ class BottomSheetRoleChangeFragment : BottomSheetDialogFragment(), AdapterView.O
         ).also { arrayAdapter ->
             popupSpinner.adapter = arrayAdapter
             popupSpinner.prompt = "Role Change Request"
-            popupSpinner.setSelection(0, true)
             arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-            popupSpinner.onItemSelectedListener = this
+            popupSpinner.post { popupSpinner.onItemSelectedListener = this }
         }
     }
 
@@ -86,5 +85,6 @@ class BottomSheetRoleChangeFragment : BottomSheetDialogFragment(), AdapterView.O
 
     override fun onNothingSelected(parent: AdapterView<*>?) {
         Log.d(TAG, "Nothing selected")
+        findNavController().popBackStack()
     }
 }


### PR DESCRIPTION
It wasn't allowing the first option to be selected since that was "already selected". No spinner can be created which has no option selected.
Also updates the peer when the role is changed.