### PR TITLE
HMS-2231,  black tiles issues & updated webrtc

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "live.hms.app2"
         minSdkVersion 24
         targetSdkVersion 30
-        versionCode 145
-        versionName "2.0.86"
+        versionCode 146
+        versionName "2.0.87"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -60,8 +60,10 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     //100ms.live SDK
-    implementation 'org.webrtc:google-webrtc:1.0.32006'
-    implementation 'com.github.100mslive:android-sdk:2.0.8'
+    implementation "com.github.100mslive:webrtc:WebRTC-source-stamp-2021-08-20T04_05_25"
+    //implementation 'com.github.100mslive:android-sdk:2.0.8'
+    implementation project(':lib')
+
 
     // Navigation
     implementation "androidx.navigation:navigation-fragment-ktx:2.3.5"

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -430,7 +430,6 @@ class MeetingViewModel(
       }
 
       val _track = _tracks.find {
-        it.audio == null &&
                 it.peer.peerID == peer.peerID &&
                 it.isScreen.not()
       }
@@ -453,7 +452,7 @@ class MeetingViewModel(
   private fun addVideoTrack(track: HMSVideoTrack, peer: HMSPeer) {
     synchronized(_tracks) {
       // Check if this track already exists
-      val _track = _tracks.find { it.video == null && it.peer.peerID == peer.peerID }
+      val _track = _tracks.find {track.source != HMSTrackSource.SCREEN && it.peer.peerID == peer.peerID }
       if (_track == null) {
         if (peer.isLocal) {
           _tracks.add(0, MeetingTrack(peer, track, null))

--- a/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -120,6 +120,7 @@ abstract class VideoGridBaseFragment : Fragment() {
     if (item.peer.videoTrack == null
       || item.video == null
       || item.video?.isMute == true
+      || item.video?.isDegraded == true
       || binding.surfaceView.visibility == View.VISIBLE) return
 
     binding.surfaceView.let { view ->

--- a/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -117,7 +117,10 @@ abstract class VideoGridBaseFragment : Fragment() {
     scalingType: RendererCommon.ScalingType = RendererCommon.ScalingType.SCALE_ASPECT_BALANCED
   ) {
     Log.d(TAG,"bindSurfaceView for :: ${item.peer.name}")
-    if (item.video == null || item.video?.isMute == true) return
+    if (item.peer.videoTrack == null
+      || item.video == null
+      || item.video?.isMute == true
+      || binding.surfaceView.visibility == View.VISIBLE) return
 
     binding.surfaceView.let { view ->
       view.setScalingType(scalingType)
@@ -147,14 +150,20 @@ abstract class VideoGridBaseFragment : Fragment() {
       icDegraded.visibility = if(item.video?.isDegraded == true) View.VISIBLE else View.GONE
 
       /** [View.setVisibility] */
-      val surfaceViewVisibility = if (item.video == null || item.video?.isMute == true || item.video?.isDegraded == true) {
+      val surfaceViewVisibility = if (item.peer.videoTrack == null
+        || item.video == null
+        || item.video?.isMute == true
+        || item.video?.isDegraded == true) {
         View.INVISIBLE
       } else {
         View.VISIBLE
       }
 
       if (surfaceView.visibility != surfaceViewVisibility) {
-        surfaceView.visibility = surfaceViewVisibility
+        if (surfaceViewVisibility == View.VISIBLE)
+          bindSurfaceView(binding, item)
+        else
+          unbindSurfaceView(binding, item)
       }
     }
   }


### PR DESCRIPTION
Also updated webrtc lib

Black tiles were happening as the binding and unbinding of tiles were not always based on tracks. Few changes in roles resulted in black tiles. Also going to background and foreground resulted in black tiles in certain cases