### PR TITLE
Setting the surfaceview invisible if it was degraded.

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -120,7 +120,6 @@ abstract class VideoGridBaseFragment : Fragment() {
     if (item.peer.videoTrack == null
       || item.video == null
       || item.video?.isMute == true
-      || item.video?.isDegraded == true
       || binding.surfaceView.visibility == View.VISIBLE) return
 
     binding.surfaceView.let { view ->
@@ -129,7 +128,7 @@ abstract class VideoGridBaseFragment : Fragment() {
 
       SurfaceViewRendererUtil.bind(view, item).let {
         if (it) {
-          binding.surfaceView.visibility = View.VISIBLE
+          binding.surfaceView.visibility = if (item.video?.isDegraded == true ) View.INVISIBLE else View.VISIBLE
           bindedVideoTrackIds.add(item.video!!.trackId)
         }
       }

--- a/app/src/main/java/live/hms/app2/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
@@ -16,6 +16,7 @@ import live.hms.app2.ui.meeting.MeetingTrack
 import live.hms.app2.ui.meeting.MeetingViewModel
 import live.hms.app2.ui.meeting.MeetingViewModelFactory
 import live.hms.app2.util.*
+import live.hms.video.media.tracks.HMSVideoTrack
 import org.webrtc.RendererCommon
 
 class PinnedVideoFragment : Fragment() {
@@ -112,7 +113,7 @@ class PinnedVideoFragment : Fragment() {
       binding.pinVideo.surfaceView.apply {
         if (isViewVisible) {
           SurfaceViewRendererUtil.bind(this, track).let { success ->
-            if (success) visibility = View.VISIBLE
+            if (success) visibility = if ((track as HMSVideoTrack).isDegraded) View.INVISIBLE else View.VISIBLE
           }
         } else {
           SurfaceViewRendererUtil.unbind(this, track)
@@ -139,7 +140,7 @@ class PinnedVideoFragment : Fragment() {
         }
 
         SurfaceViewRendererUtil.bind(this, track).let { success ->
-          if (success) visibility = View.VISIBLE
+          if (success) visibility = if ((track as HMSVideoTrack).isDegraded) View.INVISIBLE else View.VISIBLE
         }
       }
     }

--- a/app/src/main/java/live/hms/app2/ui/meeting/pinnedvideo/VideoListAdapter.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/pinnedvideo/VideoListAdapter.kt
@@ -12,6 +12,7 @@ import live.hms.app2.ui.meeting.MeetingTrack
 import live.hms.app2.util.NameUtils
 import live.hms.app2.util.SurfaceViewRendererUtil
 import live.hms.app2.util.crashlyticsLog
+import live.hms.video.media.tracks.HMSVideoTrack
 import org.webrtc.RendererCommon
 
 class VideoListAdapter(
@@ -78,7 +79,7 @@ class VideoListAdapter(
           "VideoItemViewHolder::bindSurfaceView"
         ).let { success ->
           if (success) {
-            binding.surfaceView.visibility = View.VISIBLE
+            binding.surfaceView.visibility = if ((item.track as HMSVideoTrack).isDegraded) View.INVISIBLE else View.VISIBLE
             isSurfaceViewBinded = true
           }
         }


### PR DESCRIPTION
This makes sure to call addsink and sets the surfaceview invisible directly as well. This isn't as required right now since the surface view is invisible usually but helps avoid regressions.