### PR TITLE
Fix for flickering in gridview.

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -13,9 +13,7 @@ import live.hms.app2.databinding.VideoCardBinding
 import live.hms.app2.ui.meeting.MeetingTrack
 import live.hms.app2.ui.meeting.MeetingViewModel
 import live.hms.app2.ui.settings.SettingsStore
-import live.hms.app2.util.NameUtils
-import live.hms.app2.util.SurfaceViewRendererUtil
-import live.hms.app2.util.crashlyticsLog
+import live.hms.app2.util.*
 import live.hms.app2.util.visibility
 import live.hms.video.sdk.models.HMSSpeaker
 import org.webrtc.RendererCommon
@@ -139,14 +137,18 @@ abstract class VideoGridBaseFragment : Fragment() {
     // binding.container.setOnClickListener { viewModel.onVideoItemClick?.invoke(item) }
 
     binding.apply {
-      name.text = item.peer.name
-      nameInitials.text = NameUtils.getInitials(item.peer.name)
-      iconScreenShare.visibility = if (item.isScreen) View.VISIBLE else View.GONE
-      iconAudioOff.visibility = visibility(
+      // Donot update the text view if not needed, this causes redraw of the entire view leading to  flicker
+      if (name.text.equals(item.peer.name).not()) {
+        name.text = item.peer.name
+        nameInitials.text = NameUtils.getInitials(item.peer.name)
+      }
+      // Using alpha instead of visibility to stop redraw of the entire view to stop flickering
+      iconScreenShare.alpha = visibilityOpacity( (item.isScreen) )
+      iconAudioOff.alpha = visibilityOpacity(
         item.isScreen.not() &&
             (item.audio == null || item.audio!!.isMute)
       )
-      icDegraded.visibility = if(item.video?.isDegraded == true) View.VISIBLE else View.GONE
+      icDegraded.alpha = visibilityOpacity(item.video?.isDegraded == true)
 
       /** [View.setVisibility] */
       val surfaceViewVisibility = if (item.peer.videoTrack == null

--- a/app/src/main/java/live/hms/app2/ui/meeting/videogrid/VideoGridPageFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/videogrid/VideoGridPageFragment.kt
@@ -62,6 +62,6 @@ class VideoGridPageFragment : VideoGridBaseFragment() {
       updateVideos(binding.container, videos)
     }
 
-    meetingViewModel.speakers.observe(viewLifecycleOwner) { applySpeakerUpdates(it) }
+    //meetingViewModel.speakers.observe(viewLifecycleOwner) { applySpeakerUpdates(it) }
   }
 }

--- a/app/src/main/java/live/hms/app2/util/Utils.kt
+++ b/app/src/main/java/live/hms/app2/util/Utils.kt
@@ -18,3 +18,9 @@ fun visibility(show: Boolean) = if (show) {
 } else {
   View.GONE
 }
+
+fun visibilityOpacity(show: Boolean) = if (show) {
+  1.0f
+} else {
+  0.0f
+}


### PR DESCRIPTION
Binding of each video tile happens whenever there is any change in MeetingTrack.
1. Change visibility to alpha as changing visibilty was causing redraw of the entire tile
2. Donot settext if name not updated, else it causes redraw of the tile