### PR TITLE
Fix app side unmuting of newly added tracks even if the SDK muted them

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -430,8 +430,8 @@ class MeetingViewModel(
 
   private fun addAudioTrack(track: HMSAudioTrack, peer: HMSPeer) {
     synchronized(_tracks) {
-      if (track is HMSRemoteAudioTrack) {
-        track.setVolume(if (isAudioMuted) 0.0 else 1.0)
+      if (isAudioMuted && track is HMSRemoteAudioTrack) {
+        track.setVolume(0.0) // Only keep people muted. Don't unmute those who come in add track because it might break SDK level muting.
       }
 
       // Check if this track is of screenshare type, then we dont need to show a tile
@@ -440,7 +440,7 @@ class MeetingViewModel(
 
       // Check if this track already exists
       val _track = _tracks.find {
-                it.peer.peerID == peer.peerID &&
+        it.peer.peerID == peer.peerID &&
                 it.isScreen.not()
       }
 


### PR DESCRIPTION
Only mute incoming tracks in add track, if required don't unmute them.
This only applies to tracks newly added so it will not affect actual unmuting behaviour which sets unmute during isAudioMuted value changes.