### PR TITLE
Fix/requested by is nullable in change track request

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingFragment.kt
@@ -423,9 +423,9 @@ class MeetingFragment : Fragment() {
           is MeetingViewModel.Event.ChangeTrackMuteRequest -> {
             withContext(Dispatchers.Main) {
               val message = if (event.request.track is HMSLocalAudioTrack) {
-                "${event.request.requestedBy.name} is asking you to unmute."
+                "${event.request.requestedBy?.name ?: "A peer"} is asking you to unmute."
               } else {
-                "${event.request.requestedBy.name} is asking you to turn on video."
+                "${event.request.requestedBy?.name ?: "A peer"} is asking you to turn on video."
               }
 
               val builder = AlertDialog.Builder(requireContext())

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -396,7 +396,9 @@ class MeetingViewModel(
 
         override fun onChangeTrackStateRequest(details: HMSChangeTrackStateRequest) {
           viewModelScope.launch {
-            _events.emit(Event.ChangeTrackMuteRequest(details))
+            if (details.track.isMute != details.mute) {
+              _events.emit(Event.ChangeTrackMuteRequest(details))
+            }
           }
         }
       })


### PR DESCRIPTION
Avoids the double mute request dialog when a person is muted by a remote peer.
Also includes allowing for `requestedBy` to be null.