### PR TITLE
HMS-4954: Fix/empty set crash

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/settings/SettingsStore.kt
+++ b/app/src/main/java/live/hms/app2/ui/settings/SettingsStore.kt
@@ -228,8 +228,7 @@ class SettingsStore(context: Context) {
     get() = sharedPreferences.getStringSet(
       RTMP_URL_LIST,
       if (BuildConfig.RTMP_INJEST_URL.isEmpty()) emptySet<String>() else setOf(BuildConfig.RTMP_INJEST_URL)
-    )!!
-      .toSet()
+    )?.toSet() ?: emptySet()
     set(value) = putStringSet(RTMP_URL_LIST, value)
 
 


### PR DESCRIPTION
In this case, return an empty set instead.