### PR TITLE
Fix: IllegalStateException: Called before onCreateView or after onDestroyView on PreviewFragment

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/PreviewFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/PreviewFragment.kt
@@ -241,7 +241,7 @@ class PreviewFragment : Fragment() {
 
   private fun initObservers() {
 
-    meetingViewModel.previewErrorLiveData.observe(requireActivity()) { error ->
+    meetingViewModel.previewErrorLiveData.observe(viewLifecycleOwner) { error ->
       if (error.isTerminal) {
         binding.buttonJoinMeeting.isEnabled = false
         AlertDialog.Builder(requireContext())
@@ -265,7 +265,7 @@ class PreviewFragment : Fragment() {
       }
     }
 
-    meetingViewModel.previewPeerLiveData.observe(requireActivity()) { (type, peer) ->
+    meetingViewModel.previewPeerLiveData.observe(viewLifecycleOwner) { (type, peer) ->
       val peerToUpdate = participantsDialogAdapter?.getItems()?.firstOrNull {
         it.peerID == peer.peerID
       }
@@ -276,7 +276,7 @@ class PreviewFragment : Fragment() {
     }
 
     meetingViewModel.previewUpdateLiveData.observe(
-      requireActivity(),
+      viewLifecycleOwner,
       Observer { (room, localTracks) ->
         binding.nameInitials.text = NameUtils.getInitials(room.localPeer!!.name)
         binding.buttonJoinMeeting.isEnabled = true
@@ -320,7 +320,7 @@ class PreviewFragment : Fragment() {
         }
       })
 
-    meetingViewModel.previewRoomStateLiveData.observe(requireActivity(), Observer { (_,room) ->
+    meetingViewModel.previewRoomStateLiveData.observe(viewLifecycleOwner, Observer { (_,room) ->
       //          binding.peerCount.text = hmsRoom.peerCount.toString()
       participantsDialogAdapter?.setItems(getRemotePeers(room).toTypedArray())
     })


### PR DESCRIPTION
Providing viewLifecycleOwner to observe on LiveData instead of ActivityLifecycle which was causing a crash if any live data got updated after the views were destroyed