### PR TITLE
Lifecycle view crash fix

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -193,6 +193,9 @@ class MeetingViewModel(
 
   val broadcastsReceived = MutableLiveData<ChatMessage>()
 
+  private val _trackStatus = MutableLiveData<String>()
+  val trackStatus: LiveData<String> = _trackStatus
+
   private val hmsTrackSettings = HMSTrackSettings.Builder()
     .audio(
       HMSAudioTrackSettings.Builder()
@@ -1169,6 +1172,10 @@ class MeetingViewModel(
 
       }
     })
+  }
+
+  fun updateTrackStatus(status: String) {
+    _trackStatus.value = status
   }
 }
 

--- a/app/src/main/java/live/hms/app2/ui/meeting/activespeaker/ActiveSpeakerFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/activespeaker/ActiveSpeakerFragment.kt
@@ -49,7 +49,7 @@ class ActiveSpeakerFragment : VideoGridBaseFragment() {
         it.video,
         it.audio, it.peer.isLocal
       ) { statsString ->
-        binding.screenShare.statsView.text = statsString
+        meetingViewModel?.updateTrackStatus(statsString)
       }
       binding.screenShare.raisedHand.alpha = visibilityOpacity(CustomPeerMetadata.fromJson(it.peer.metadata)?.isHandRaised == true)
       bindSurfaceView(binding.screenShare, it, RendererCommon.ScalingType.SCALE_ASPECT_FIT)
@@ -97,6 +97,10 @@ class ActiveSpeakerFragment : VideoGridBaseFragment() {
           else -> {}
         }
       }
+    }
+
+    meetingViewModel.trackStatus.observe(viewLifecycleOwner) { statsString ->
+      binding.screenShare.statsView.text = statsString
     }
   }
 


### PR DESCRIPTION
added fix for 
```Fatal Exception: java.lang.IllegalStateException: Called before onCreateView or after onDestroyView.
       at live.hms.app2.util.ViewBindingLifecycleExtensionKt$viewLifecycle$1.getValue(ViewBindingLifecycleExtension.kt:37)
       at live.hms.app2.util.ViewBindingLifecycleExtensionKt$viewLifecycle$1.getValue(ViewBindingLifecycleExtension.kt:24)
       at live.hms.app2.ui.meeting.activespeaker.ActiveSpeakerFragment.getBinding(ActiveSpeakerFragment.kt:24)
       at live.hms.app2.ui.meeting.activespeaker.ActiveSpeakerFragment.access$getBinding(ActiveSpeakerFragment.kt:18)
       at live.hms.app2.ui.meeting.activespeaker.ActiveSpeakerFragment$onResume$1$1.invoke(ActiveSpeakerFragment.kt:52)
       at live.hms.app2.ui.meeting.activespeaker.ActiveSpeakerFragment$onResume$1$1.invoke(ActiveSpeakerFragment.kt:46)
       at live.hms.app2.ui.meeting.pinnedvideo.StatsInterpreter$initiateStats$1$3$1.invokeSuspend(StatsInterpreter.kt:51)
       at live.hms.app2.ui.meeting.pinnedvideo.StatsInterpreter$initiateStats$1$3$1.invoke(:8)
       at live.hms.app2.ui.meeting.pinnedvideo.StatsInterpreter$initiateStats$1$3$1.invoke(:4)
       at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:89)
       at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(Builders.common.kt:165)```