### PR TITLE
Show streaming and recording states in preview

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingActivity.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingActivity.kt
@@ -103,7 +103,7 @@ class MeetingActivity : AppCompatActivity() {
         RecordingState.RECORDING -> {
           // red
           isVisible = true
-          this.icon.setTint(Color.parseColor("#e04848"))
+          this.icon.setTint(getColor(R.color.recording))
         }
         RecordingState.NOT_RECORDING_OR_STREAMING -> {
           isVisible = false
@@ -113,19 +113,19 @@ class MeetingActivity : AppCompatActivity() {
           // White
           isVisible = true
           // change the colour to transitioning
-          this.icon.setTint(Color.parseColor("#FFFFFF"))
+          this.icon.setTint(getColor(R.color.recording_transition))
         }
         RecordingState.STREAMING -> {
           // Blue
           isVisible = true
-          this.icon.setTint(Color.parseColor("#2832c2"))
+          this.icon.setTint(getColor(R.color.streaming))
         }
         RecordingState.STREAMING_AND_RECORDING -> {
           // Orange
           isVisible = true
-          this.icon.setTint(Color.parseColor("#FFC107"))
+          this.icon.setTint(getColor(R.color.streaming_recording))
         }
-        null -> TODO()
+        else ->{}
       }
 
       setOnMenuItemClickListener {

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingActivity.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingActivity.kt
@@ -2,6 +2,7 @@ package live.hms.app2.ui.meeting
 
 import android.annotation.SuppressLint
 import android.content.res.Configuration
+import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
 import android.view.View
@@ -9,6 +10,7 @@ import android.view.WindowManager
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.menu.MenuBuilder
+import androidx.core.view.forEach
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import live.hms.app2.R
@@ -82,5 +84,55 @@ class MeetingActivity : AppCompatActivity() {
     meetingViewModel.title.observe(this) {
       binding.containerToolbar.toolbar.setTitle(it)
     }
+    meetingViewModel.isRecording.observe(this) {
+      invalidateOptionsMenu()
+    }
+  }
+
+  override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
+    super.onPrepareOptionsMenu(menu)
+
+    menu?.forEach { item ->
+      if (item.itemId != R.id.action_flip_camera && item.itemId != R.id.action_volume && item.itemId != R.id.action_participants) {
+        item.isVisible = false
+      }
+    }
+
+    menu?.findItem(R.id.action_record)?.apply {
+      when (meetingViewModel.isRecording.value) {
+        RecordingState.RECORDING -> {
+          // red
+          isVisible = true
+          this.icon.setTint(Color.parseColor("#e04848"))
+        }
+        RecordingState.NOT_RECORDING_OR_STREAMING -> {
+          isVisible = false
+        }
+        RecordingState.NOT_RECORDING_TRANSITION_IN_PROGRESS,
+        RecordingState.RECORDING_TRANSITIONING_TO_NOT_RECORDING -> {
+          // White
+          isVisible = true
+          // change the colour to transitioning
+          this.icon.setTint(Color.parseColor("#FFFFFF"))
+        }
+        RecordingState.STREAMING -> {
+          // Blue
+          isVisible = true
+          this.icon.setTint(Color.parseColor("#2832c2"))
+        }
+        RecordingState.STREAMING_AND_RECORDING -> {
+          // Orange
+          isVisible = true
+          this.icon.setTint(Color.parseColor("#FFC107"))
+        }
+        null -> TODO()
+      }
+
+      setOnMenuItemClickListener {
+        meetingViewModel.stopRecording()
+        true
+      }
+    }
+    return false
   }
 }

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingFragment.kt
@@ -261,48 +261,6 @@ class MeetingFragment : Fragment() {
       }
     }
 
-    menu.findItem(R.id.action_record_meeting).apply {
-      isVisible = true
-
-      // If we're in a transitioning state, we prevent further clicks.
-      // Checked or not checked depends on if it's currently recording or not. Checked if recording.
-      when (meetingViewModel.isRecording.value) {
-        RecordingState.STREAMING -> {
-          this.isChecked = true
-          this.isEnabled = true
-          this.title = "Streaming"
-        }
-        RecordingState.STREAMING_AND_RECORDING -> {
-          this.isChecked = true
-          this.isEnabled = true
-          this.title = "Rec+Stream"
-        }
-        RecordingState.RECORDING -> {
-          this.isChecked = true
-          this.isEnabled = true
-          this.title = "Recording"
-        }
-        RecordingState.NOT_RECORDING_OR_STREAMING -> {
-          this.isChecked = false
-          this.isEnabled = true
-          this.title = "Rec+Stream"
-        }
-        RecordingState.RECORDING_TRANSITIONING_TO_NOT_RECORDING -> {
-          this.isChecked = true
-          this.isEnabled = false
-          this.title = "Recording"
-        }
-        RecordingState.NOT_RECORDING_TRANSITION_IN_PROGRESS -> {
-          this.isChecked = false
-          this.isEnabled = false
-          this.title = "Recording"
-        }
-        else -> {
-          this.title = "Recording"
-        } // Nothing
-      }
-    }
-
     menu.findItem(R.id.end_room).apply {
       isVisible = meetingViewModel.isAllowedToEndMeeting()
 
@@ -429,42 +387,6 @@ class MeetingFragment : Fragment() {
     menu.findItem(R.id.action_flip_camera).apply {
       val ok = meetingViewModel.meetingViewMode.value != MeetingViewMode.AUDIO_ONLY
       isVisible = ok
-    }
-
-    menu.findItem(R.id.action_record).apply {
-      when (meetingViewModel.isRecording.value) {
-        RecordingState.RECORDING -> {
-          // red
-          isVisible = true
-          this.icon.setTint(Color.parseColor("#e04848"))
-        }
-        RecordingState.NOT_RECORDING_OR_STREAMING -> {
-          isVisible = false
-        }
-        RecordingState.NOT_RECORDING_TRANSITION_IN_PROGRESS,
-        RecordingState.RECORDING_TRANSITIONING_TO_NOT_RECORDING -> {
-          // White
-          isVisible = true
-          // change the colour to transitioning
-          this.icon.setTint(Color.parseColor("#FFFFFF"))
-        }
-        RecordingState.STREAMING -> {
-          // Blue
-          isVisible = true
-          this.icon.setTint(Color.parseColor("#2832c2"))
-        }
-        RecordingState.STREAMING_AND_RECORDING -> {
-          // Orange
-          isVisible = true
-          this.icon.setTint(Color.parseColor("#FFC107"))
-        }
-        null -> TODO()
-      }
-
-      setOnMenuItemClickListener {
-        meetingViewModel.stopRecording()
-        true
-      }
     }
 
     menu.findItem(R.id.action_volume).apply {

--- a/app/src/main/java/live/hms/app2/ui/meeting/PreviewFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/PreviewFragment.kt
@@ -178,16 +178,6 @@ class PreviewFragment : Fragment() {
     }
   }
 
-  override fun onPrepareOptionsMenu(menu: Menu) {
-    super.onPrepareOptionsMenu(menu)
-
-    menu.forEach { item ->
-      if (item.itemId != R.id.action_flip_camera && item.itemId != R.id.action_volume && item.itemId != R.id.action_participants) {
-        item.isVisible = false
-      }
-    }
-  }
-
   private fun updateActionVolumeMenuIcon(item: MenuItem) {
     item.apply {
       if (meetingViewModel.isPeerAudioEnabled()) {

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,4 +17,8 @@
     <color name="white">#ffffff</color>
     <color name="white_faded_30">#4dffffff</color>
     <color name="white_faded_70">#b3ffffff</color>
+    <color name="recording">#e04848</color>
+    <color name="recording_transition">#FFFFFF</color>
+    <color name="streaming">#2832c2</color>
+    <color name="streaming_recording">#FFC107</color>
 </resources>


### PR DESCRIPTION
Instead of handling the red dot in meeting/preview fragments, it's moved to the activity and triggered on the viewModel's isRecording state.
Since the value will be destroyed for HomeFragment it won't show up there.