### PR TITLE
partial dev to release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,8 +61,8 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
 
     //100ms.live SDK
-    implementation 'com.github.100mslive.android-sdk:lib:2.3.7'
-    implementation 'com.github.100mslive.android-sdk:virtualBackground:2.3.7'
+    implementation 'com.github.100mslive.android-sdk:lib:2.4.1'
+    implementation 'com.github.100mslive.android-sdk:virtualBackground:2.4.1'
 
     // Navigation
     implementation "androidx.navigation:navigation-fragment-ktx:2.4.0"

--- a/app/src/main/java/live/hms/app2/ui/home/permission/PermissionFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/home/permission/PermissionFragment.kt
@@ -27,7 +27,7 @@ class PermissionFragment : Fragment(), EasyPermissions.PermissionCallbacks {
     Manifest.permission.FOREGROUND_SERVICE)
       private val PERMISSIONS_MINIMAL =
           arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
-    private val PERMISSIONS_API_31 = arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO,
+    private val PERMISSIONS_API_S = arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO,
       Manifest.permission.FOREGROUND_SERVICE,Manifest.permission.BLUETOOTH_CONNECT)
   }
 
@@ -75,7 +75,7 @@ class PermissionFragment : Fragment(), EasyPermissions.PermissionCallbacks {
           this,
           resources.getString(R.string.permission_description),
           RC_CALL,
-          *PERMISSIONS_API_31
+          *PERMISSIONS_API_S
         )
       }else{
         EasyPermissions.requestPermissions(
@@ -95,7 +95,7 @@ class PermissionFragment : Fragment(), EasyPermissions.PermissionCallbacks {
            }
        }
        else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S){
-          if (EasyPermissions.hasPermissions(requireContext(), *PERMISSIONS_API_31)){
+          if (EasyPermissions.hasPermissions(requireContext(), *PERMISSIONS_API_S)){
             return true
           }
        }

--- a/app/src/main/java/live/hms/app2/ui/home/permission/PermissionFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/home/permission/PermissionFragment.kt
@@ -27,6 +27,8 @@ class PermissionFragment : Fragment(), EasyPermissions.PermissionCallbacks {
     Manifest.permission.FOREGROUND_SERVICE)
       private val PERMISSIONS_MINIMAL =
           arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO)
+    private val PERMISSIONS_API_31 = arrayOf(Manifest.permission.CAMERA, Manifest.permission.RECORD_AUDIO,
+      Manifest.permission.FOREGROUND_SERVICE,Manifest.permission.BLUETOOTH_CONNECT)
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -68,12 +70,21 @@ class PermissionFragment : Fragment(), EasyPermissions.PermissionCallbacks {
         PermissionFragmentDirections.actionPermissionFragmentToHomeFragment()
       )
     } else {
-      EasyPermissions.requestPermissions(
-        this,
-        resources.getString(R.string.permission_description),
-        RC_CALL,
-        *PERMISSIONS
-      )
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S){
+        EasyPermissions.requestPermissions(
+          this,
+          resources.getString(R.string.permission_description),
+          RC_CALL,
+          *PERMISSIONS_API_31
+        )
+      }else{
+        EasyPermissions.requestPermissions(
+          this,
+          resources.getString(R.string.permission_description),
+          RC_CALL,
+          *PERMISSIONS
+        )
+      }
     }
   }
 
@@ -82,7 +93,13 @@ class PermissionFragment : Fragment(), EasyPermissions.PermissionCallbacks {
            if (EasyPermissions.hasPermissions(requireContext(), *PERMISSIONS_MINIMAL)) {
                return true
            }
-       } else if (EasyPermissions.hasPermissions(requireContext(), *PERMISSIONS)) {
+       }
+       else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S){
+          if (EasyPermissions.hasPermissions(requireContext(), *PERMISSIONS_API_31)){
+            return true
+          }
+       }
+       else if (EasyPermissions.hasPermissions(requireContext(), *PERMISSIONS)) {
             return true
        }
        return false

--- a/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatMessage.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatMessage.kt
@@ -5,7 +5,7 @@ import java.util.*
 
 data class ChatMessage(
     val senderName: String,
-    val time: Date,
+    val time: Long,
     val message: String,
     val isSentByMe: Boolean,
     val recipient: Recipient

--- a/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatViewModel.kt
@@ -33,7 +33,7 @@ class ChatViewModel(private val hmssdk: HMSSDK) : ViewModel() {
 
     val message = ChatMessage(
       "You",
-      Date(),
+      System.currentTimeMillis(),
       messageStr,
       true,
       Recipient.Everyone

--- a/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -128,10 +128,10 @@ abstract class VideoGridBaseFragment : Fragment() {
     scalingType: RendererCommon.ScalingType = RendererCommon.ScalingType.SCALE_ASPECT_BALANCED
   ) {
     Log.d(TAG,"bindSurfaceView for :: ${item.peer.name}")
-    if (item.peer.videoTrack == null
-      || item.video == null
-      || item.video?.isMute == true
-      || bindedVideoTrackIds.contains(item.video?.trackId)) return
+    val earlyExit = item.video == null
+            || item.video?.isMute == true
+            || bindedVideoTrackIds.contains(item.video?.trackId)
+    if (earlyExit) return
 
     binding.surfaceView.let { view ->
       view.setScalingType(scalingType)
@@ -165,8 +165,7 @@ abstract class VideoGridBaseFragment : Fragment() {
       icDegraded.alpha = visibilityOpacity(item.video?.isDegraded == true)
 
       /** [View.setVisibility] */
-      val surfaceViewVisibility = if (item.peer.videoTrack == null
-        || item.video == null
+      val surfaceViewVisibility = if (item.video == null
         || item.video?.isMute == true
         || item.video?.isDegraded == true) {
         View.INVISIBLE


### PR DESCRIPTION
There's an incomptibility between the current release sdk and app versions, this corrects it.

- Update ChatMessage.kt
- Update ChatViewModel.kt
- Because we were always looking for item.peer.videotrack which isn't present in screenshares, it would exit early. We should instead rely only on what the meetingtrack says is the video.
- 1. permission added for android 12
- 1. permission added for android 12
- Corrected sdk version numbers
