### PR TITLE
stream permissions fix

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingFragment.kt
@@ -294,7 +294,7 @@ class MeetingFragment : Fragment() {
     }
 
     menu.findItem(R.id.action_record_meeting).apply {
-      isVisible = meetingViewModel.isAllowedToBrowserRecord()
+      isVisible = meetingViewModel.isAllowedToBrowserRecord() || meetingViewModel.isAllowedToRtmpStream()
 
       // If we're in a transitioning state, we prevent further clicks.
       // Checked or not checked depends on if it's currently recording or not. Checked if recording.


### PR DESCRIPTION
Showing the recording fragment when streaming is enabled, this should be cleaned up after the hls 
UI is merged.
