### PR TITLE
AN 730 make meeting url and rtmp urls optional in hms recording config

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -1165,8 +1165,8 @@ class MeetingViewModel(
 
     fun recordMeeting(
         isRecording: Boolean,
-        rtmpInjectUrls: List<String>,
-        meetingUrl: String,
+        rtmpInjectUrls: List<String>?,
+        meetingUrl: String?,
         inputWidthHeight: HMSRtmpVideoResolution?
     ) {
         // It's streaming if there are rtmp urls present.

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -1165,7 +1165,7 @@ class MeetingViewModel(
 
     fun recordMeeting(
         isRecording: Boolean,
-        rtmpInjectUrls: List<String>?,
+        rtmpInjectUrls: List<String>,
         inputWidthHeight: HMSRtmpVideoResolution?
     ) {
         // It's streaming if there are rtmp urls present.

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -684,7 +684,8 @@ class MeetingViewModel(
                         message.serverReceiveTime,
                         message.message,
                         false,
-                        recipient = Recipient.toRecipient(message.recipient)
+                        recipient = Recipient.toRecipient(message.recipient),
+                        message.messageId
                     )
                 )
             }

--- a/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/MeetingViewModel.kt
@@ -19,7 +19,6 @@ import live.hms.app2.model.RoomDetails
 import live.hms.app2.ui.meeting.activespeaker.ActiveSpeakerHandler
 import live.hms.app2.ui.meeting.chat.ChatMessage
 import live.hms.app2.ui.meeting.chat.Recipient
-import live.hms.app2.ui.meeting.commons.VideoGridBaseFragment
 import live.hms.app2.ui.settings.SettingsFragment.Companion.REAR_FACING_CAMERA
 import live.hms.app2.ui.settings.SettingsStore
 import live.hms.app2.util.*
@@ -1166,15 +1165,14 @@ class MeetingViewModel(
     fun recordMeeting(
         isRecording: Boolean,
         rtmpInjectUrls: List<String>?,
-        meetingUrl: String?,
         inputWidthHeight: HMSRtmpVideoResolution?
     ) {
         // It's streaming if there are rtmp urls present.
 
-        Log.v(TAG, "Starting recording")
+        Log.v(TAG, "Starting recording. url: $rtmpInjectUrls")
         hmsSDK.startRtmpOrRecording(
             HMSRecordingConfig(
-                meetingUrl,
+                null,
                 rtmpInjectUrls,
                 isRecording,
                 inputWidthHeight

--- a/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatMessage.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatMessage.kt
@@ -3,18 +3,20 @@ package live.hms.app2.ui.meeting.chat
 import live.hms.video.sdk.models.HMSMessage
 import java.util.*
 
-data class ChatMessage(
+data class ChatMessage constructor(
     val senderName: String,
-    val time: Long,
+    val time: Long? = null,
     val message: String,
     val isSentByMe: Boolean,
-    val recipient: Recipient
+    val recipient: Recipient,
+    var messageId : String? = null,
 ) {
     constructor(message: HMSMessage, sentByMe: Boolean) : this(
         message.sender?.name.orEmpty(),
         message.serverReceiveTime,
         message.message,
         sentByMe,
-        Recipient.toRecipient(message.recipient)
+        Recipient.toRecipient(message.recipient),
+        messageId = message.messageId
     )
 }

--- a/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatViewModel.kt
@@ -33,7 +33,7 @@ class ChatViewModel(private val hmssdk: HMSSDK) : ViewModel() {
 
     val message = ChatMessage(
       "You",
-      System.currentTimeMillis(),
+      null, // Let the server alone set the time
       messageStr,
       true,
       Recipient.Everyone
@@ -60,7 +60,7 @@ class ChatViewModel(private val hmssdk: HMSSDK) : ViewModel() {
 
       override fun onSuccess(hmsMessage: HMSMessage) {
         // Request Successfully sent to server
-        addMessage(ChatMessage(hmsMessage, true))
+        addMessage(ChatMessage(hmsMessage, true).appendMessageIdForTest())
       }
 
     })
@@ -75,7 +75,7 @@ class ChatViewModel(private val hmssdk: HMSSDK) : ViewModel() {
 
       override fun onSuccess(hmsMessage: HMSMessage) {
         // Request Successfully sent to server
-        addMessage(ChatMessage(hmsMessage, true))
+        addMessage(ChatMessage(hmsMessage, true).appendMessageIdForTest())
       }
 
     })
@@ -90,7 +90,7 @@ class ChatViewModel(private val hmssdk: HMSSDK) : ViewModel() {
 
       override fun onSuccess(hmsMessage: HMSMessage) {
         // Request Successfully sent to server
-        addMessage(ChatMessage(hmsMessage, true))
+        addMessage(ChatMessage(hmsMessage, true).appendMessageIdForTest())
       }
 
     })
@@ -114,7 +114,7 @@ class ChatViewModel(private val hmssdk: HMSSDK) : ViewModel() {
   fun receivedMessage(message: ChatMessage) {
     Log.v(TAG, "receivedMessage: $message")
     unreadMessagesCount.postValue(unreadMessagesCount.value?.plus(1))
-    addMessage(message)
+    addMessage(message.appendMessageIdForTest())
   }
 
   fun peersUpdate() {
@@ -140,4 +140,8 @@ class ChatViewModel(private val hmssdk: HMSSDK) : ViewModel() {
   init {
     peersUpdate() // Load up local peers into the chat members.
   }
+}
+
+fun ChatMessage.appendMessageIdForTest(): ChatMessage {
+  return this.copy(message = "${this.messageId?.takeLast(8)}: ${this.message}" )
 }

--- a/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatViewModel.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/chat/ChatViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import live.hms.app2.BuildConfig
 import live.hms.video.error.HMSException
 import live.hms.video.sdk.HMSMessageResultListener
 import live.hms.video.sdk.HMSSDK
@@ -143,5 +144,8 @@ class ChatViewModel(private val hmssdk: HMSSDK) : ViewModel() {
 }
 
 fun ChatMessage.appendMessageIdForTest(): ChatMessage {
-  return this.copy(message = "${this.messageId?.takeLast(8)}: ${this.message}" )
+  return if(BuildConfig.DEBUG)
+    this.copy(message = "${this.messageId?.takeLast(8)}: ${this.message}" )
+  else
+    this
 }

--- a/app/src/main/java/live/hms/app2/ui/meeting/participants/RtmpRecordBottomSheet.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/participants/RtmpRecordBottomSheet.kt
@@ -128,7 +128,7 @@ class RtmpRecordBottomSheet(val startClickListener: ()->Unit) : BottomSheetDialo
             dialog.show()
 
             dialog.findViewById<TextView>(R.id.btn_end_session)?.setOnClickListener{
-                if (binding.streamUrlList.childCount > 1){
+                if (binding.streamUrlList.childCount > 0){
                     binding.streamUrlList.removeView(layout)
                 }
                 dialog.dismiss()
@@ -177,9 +177,8 @@ class RtmpRecordBottomSheet(val startClickListener: ()->Unit) : BottomSheetDialo
         settings.rtmpUrlsList = newList.toSet()
 
         val isRecording = binding.shouldRecord.isChecked
-        val meetingUrl = settings.lastUsedMeetingUrl.meetingToHlsUrl()
-        val isRtmp =
-            settings.rtmpUrlsList.toList().isNotEmpty() && meetingViewModel.isAllowedToRtmpStream()
+
+        val isRtmp = meetingViewModel.isAllowedToRtmpStream()
 
         val inputWidthHeight: HMSRtmpVideoResolution? =
             checkInputWidthHeight(
@@ -187,12 +186,15 @@ class RtmpRecordBottomSheet(val startClickListener: ()->Unit) : BottomSheetDialo
                 binding.rtmpHeight.text.toString().toIntOrNull()
             )
 
+        val rtmpUrls = if(settings.rtmpUrlsList.isNotEmpty()) {
+            settings.rtmpUrlsList.toList()
+        } else
+            null
         if (isRecording || isRtmp && (inputWidthHeight?.height ?: 0) > 0 && (inputWidthHeight?.width ?: 0) > 0) {
             startClickListener.invoke()
             meetingViewModel.recordMeeting(
                 isRecording,
-                settings.rtmpUrlsList.toList(),
-                meetingUrl,
+                rtmpUrls,
                 inputWidthHeight
             )
             dismiss()

--- a/app/src/main/java/live/hms/app2/ui/meeting/participants/RtmpRecordBottomSheet.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/participants/RtmpRecordBottomSheet.kt
@@ -186,10 +186,7 @@ class RtmpRecordBottomSheet(val startClickListener: ()->Unit) : BottomSheetDialo
                 binding.rtmpHeight.text.toString().toIntOrNull()
             )
 
-        val rtmpUrls = if(settings.rtmpUrlsList.isNotEmpty()) {
-            settings.rtmpUrlsList.toList()
-        } else
-            null
+        val rtmpUrls = settings.rtmpUrlsList.toList()
         if (isRecording || isRtmp && (inputWidthHeight?.height ?: 0) > 0 && (inputWidthHeight?.width ?: 0) > 0) {
             startClickListener.invoke()
             meetingViewModel.recordMeeting(

--- a/app/src/main/java/live/hms/app2/ui/meeting/participants/RtmpRecordBottomSheet.kt
+++ b/app/src/main/java/live/hms/app2/ui/meeting/participants/RtmpRecordBottomSheet.kt
@@ -18,7 +18,7 @@ import live.hms.video.media.settings.HMSRtmpVideoResolution
 import java.net.URI
 import java.net.URISyntaxException
 
-
+private const val MIN_RTMP_URLS = 1
 class RtmpRecordBottomSheet(val startClickListener: ()->Unit) : BottomSheetDialogFragment() {
 
     private var binding by viewLifecycle<LayoutRtmpRecordingBinding>()
@@ -128,7 +128,7 @@ class RtmpRecordBottomSheet(val startClickListener: ()->Unit) : BottomSheetDialo
             dialog.show()
 
             dialog.findViewById<TextView>(R.id.btn_end_session)?.setOnClickListener{
-                if (binding.streamUrlList.childCount > 0){
+                if (binding.streamUrlList.childCount > MIN_RTMP_URLS){
                     binding.streamUrlList.removeView(layout)
                 }
                 dialog.dismiss()


### PR DESCRIPTION
- Make meetingurl and rtmpinject url optional
- Add messageId
- Limit message ids to debug builds only
- Remove meeting url, allow rtmp urls to be absent.
- Don't allow rtmp urls to be null
- Fix rtmp urls min
