### PR TITLE
fix question creator flow

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,9 +54,9 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.10.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     //100ms.live prebuilt lib
     implementation "live.100ms:room-kit:1.1.1"

--- a/room-kit/build.gradle
+++ b/room-kit/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.percentlayout:percentlayout:1.0.0'
 
-    def hmsVersion = "2.7.8"
+    def hmsVersion = "2.7.9"
     // To add dependencies of specific module
     implementation "live.100ms:android-sdk:$hmsVersion"
     implementation "live.100ms:video-view:$hmsVersion"

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -1938,7 +1938,7 @@ class MeetingViewModel(
                     hmsPollBuilder
                         .addQuestion(multiChoice.build())
                 }
-                QuestionUi.QuestionCreator,
+                is QuestionUi.QuestionCreator,
                 QuestionUi.AddAnotherItemView -> { /*Nothing to do here*/}
                 is QuestionUi.ShortAnswer -> hmsPollBuilder.addShortAnswerQuestion(questionUi.text)
                 is QuestionUi.SingleChoiceQuestion -> {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -1933,7 +1933,7 @@ class MeetingViewModel(
                     val multiChoice = HMSPollQuestionBuilder.Builder(HMSPollQuestionType.multiChoice)
                         .withTitle(questionUi.withTitle)
                     questionUi.options.forEachIndexed { index : Int, option : String ->
-                        multiChoice.addQuizOption(option, questionUi.correctOptionIndex?.contains(index) == true)
+                        multiChoice.addQuizOption(option, questionUi.selections.contains(index))
                     }
                     hmsPollBuilder
                         .addQuestion(multiChoice.build())
@@ -1943,7 +1943,7 @@ class MeetingViewModel(
                     val singleChoiceQuestionBuilder = HMSPollQuestionBuilder.Builder(HMSPollQuestionType.singleChoice)
                         .withTitle(questionUi.withTitle)
                     questionUi.options.forEachIndexed { index : Int, option : String ->
-                        singleChoiceQuestionBuilder.addQuizOption(option, questionUi.correctOptionIndex == index)
+                        singleChoiceQuestionBuilder.addQuizOption(option, isCorrect = questionUi.selections.contains(index))
                     }
                     hmsPollBuilder
                         .addQuestion(singleChoiceQuestionBuilder.build())

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -1938,8 +1938,6 @@ class MeetingViewModel(
                     hmsPollBuilder
                         .addQuestion(multiChoice.build())
                 }
-                is QuestionUi.QuestionCreator,
-                QuestionUi.AddAnotherItemView -> { /*Nothing to do here*/}
                 is QuestionUi.ShortAnswer -> hmsPollBuilder.addShortAnswerQuestion(questionUi.text)
                 is QuestionUi.SingleChoiceQuestion -> {
                     val singleChoiceQuestionBuilder = HMSPollQuestionBuilder.Builder(HMSPollQuestionType.singleChoice)
@@ -1950,6 +1948,9 @@ class MeetingViewModel(
                     hmsPollBuilder
                         .addQuestion(singleChoiceQuestionBuilder.build())
                 }
+                is QuestionUi.QuestionCreator,
+                is QuestionUi.LaunchButton,
+                QuestionUi.AddAnotherItemView, -> { /*Nothing to do here*/}
             }
         }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -1928,7 +1928,7 @@ class MeetingViewModel(
             Log.d("Polls","Processing $questionUi")
 
             when(questionUi) {
-                is QuestionUi.LongAnswer -> hmsPollBuilder.addLongAnswerQuestion(questionUi.text)
+//                is QuestionUi.LongAnswer -> hmsPollBuilder.addLongAnswerQuestion(questionUi.text)
                 is QuestionUi.MultiChoiceQuestion -> {
                     val multiChoice = HMSPollQuestionBuilder.Builder(HMSPollQuestionType.multiChoice)
                         .withTitle(questionUi.withTitle)
@@ -1938,7 +1938,7 @@ class MeetingViewModel(
                     hmsPollBuilder
                         .addQuestion(multiChoice.build())
                 }
-                is QuestionUi.ShortAnswer -> hmsPollBuilder.addShortAnswerQuestion(questionUi.text)
+//                is QuestionUi.ShortAnswer -> hmsPollBuilder.addShortAnswerQuestion(questionUi.text)
                 is QuestionUi.SingleChoiceQuestion -> {
                     val singleChoiceQuestionBuilder = HMSPollQuestionBuilder.Builder(HMSPollQuestionType.singleChoice)
                         .withTitle(questionUi.withTitle)

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/MultiChoiceQuestionOptionItem.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/MultiChoiceQuestionOptionItem.kt
@@ -1,0 +1,26 @@
+package live.hms.roomkit.ui.polls
+
+import android.view.View
+import com.xwray.groupie.viewbinding.BindableItem
+import live.hms.roomkit.R
+import live.hms.roomkit.databinding.LayoutMultiChoiceQuestionOptionItemBinding
+import live.hms.roomkit.ui.theme.applyTheme
+
+class MultiChoiceQuestionOptionItem(
+    question: QuestionUi.ChoiceQuestions,
+    val option: String
+) : BindableItem<LayoutMultiChoiceQuestionOptionItemBinding>(question.getItemId()) {
+    override fun bind(viewBinding: LayoutMultiChoiceQuestionOptionItemBinding, position: Int) {
+        with(viewBinding) {
+            applyTheme()
+            optionText.text = option
+        }
+        // We need a divider of spacing 1
+    }
+
+    override fun getLayout(): Int = R.layout.layout_multi_choice_question_option_item
+
+    override fun initializeViewBinding(view: View): LayoutMultiChoiceQuestionOptionItemBinding =
+        LayoutMultiChoiceQuestionOptionItemBinding.bind(view)
+
+}

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionViewHolder.kt
@@ -7,16 +7,23 @@ import androidx.core.widget.doOnTextChanged
 import androidx.recyclerview.widget.RecyclerView.NO_POSITION
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import live.hms.roomkit.databinding.LayoutPollQuizOptionsItemBinding
+import live.hms.roomkit.setOnSingleClickListener
 
 class OptionViewHolder(val binding : LayoutPollQuizOptionsItemBinding,
                        getItem: (position : Int) -> Option,
                        selectRadioOption : (Int) -> Unit,
                        selectCheckboxOption : (Int, Boolean) -> Unit,
+                       deleteThisOption : (position : Int) -> Unit,
                        ) : ViewHolder(binding.root) {
    var skipCheckChange = false
     init {
         if(bindingAdapterPosition != NO_POSITION) {
             binding.text.setText(getItem(bindingAdapterPosition).text)
+        }
+        binding.deleteOptionTrashButton.setOnSingleClickListener {
+            // Avoid edittext crash
+            binding.root.requestFocus()
+            deleteThisOption(bindingAdapterPosition)
         }
         binding.text.doOnTextChanged { text, _, _, _ ->
             getItem(bindingAdapterPosition).text = text.toString()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionViewHolder.kt
@@ -10,8 +10,10 @@ import live.hms.roomkit.databinding.LayoutPollQuizOptionsItemBinding
 
 class OptionViewHolder(val binding : LayoutPollQuizOptionsItemBinding,
                        getItem: (position : Int) -> Option,
-                       selectOnlyCurrentPosition : (Int) -> Unit,
-                       refreshSubmitButton : () -> Unit) : ViewHolder(binding.root) {
+                       selectRadioOption : (Int) -> Unit,
+                       selectCheckboxOption : (Int, Boolean) -> Unit,
+                       ) : ViewHolder(binding.root) {
+   var skipCheckChange = false
     init {
         if(bindingAdapterPosition != NO_POSITION) {
             binding.text.setText(getItem(bindingAdapterPosition).text)
@@ -22,18 +24,23 @@ class OptionViewHolder(val binding : LayoutPollQuizOptionsItemBinding,
         // Both set the same property, only one will be used.
         binding.radioButton.setOnCheckedChangeListener { _, isChecked ->
             // Radio buttons reset all others when selected
+            if(skipCheckChange)
+                return@setOnCheckedChangeListener
             if(isChecked)
-                selectOnlyCurrentPosition(bindingAdapterPosition)
-            refreshSubmitButton()
+                selectRadioOption(bindingAdapterPosition)
         }
         binding.checkbox.setOnCheckedChangeListener { _, isChecked ->
-            getItem(bindingAdapterPosition).isChecked = isChecked
-            refreshSubmitButton()
+            if(skipCheckChange)
+                return@setOnCheckedChangeListener
+            selectCheckboxOption(bindingAdapterPosition, isChecked)
         }
     }
+
     fun bind(option : Option) {
+        skipCheckChange = true
         binding.radioButton.isChecked = option.isChecked
         binding.checkbox.isChecked = option.isChecked
+        skipCheckChange = false
         when(option.showCheckbox) {
             true -> {
                 binding.checkbox.visibility = View.VISIBLE

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionViewHolder.kt
@@ -15,7 +15,7 @@ class OptionViewHolder(val binding : LayoutPollQuizOptionsItemBinding,
                        selectCheckboxOption : (Int, Boolean) -> Unit,
                        deleteThisOption : (position : Int) -> Unit,
                        ) : ViewHolder(binding.root) {
-   var skipCheckChange = false
+   private var skipCheckChange = false
     init {
         if(bindingAdapterPosition != NO_POSITION) {
             binding.text.setText(getItem(bindingAdapterPosition).text)

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionsListAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionsListAdapter.kt
@@ -19,6 +19,10 @@ data class Option(var text : String,
 
 class OptionsListAdapter : ListAdapter<Option, OptionViewHolder>(DIFFUTIL_CALLBACK) {
     lateinit var refreshSubmitButton :() -> Unit
+    lateinit var onOptionTextChanged : (optionIndex : Int, text : String) -> Unit
+    lateinit var onSingleOptionSelected : (optionIndex : Int) -> Unit
+    lateinit var onMultipleOptionSelected : (optionIndex : Int, selected : Boolean) -> Unit
+
 
     companion object {
         val DIFFUTIL_CALLBACK = object : DiffUtil.ItemCallback<Option>() {
@@ -34,7 +38,11 @@ class OptionsListAdapter : ListAdapter<Option, OptionViewHolder>(DIFFUTIL_CALLBA
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OptionViewHolder {
         val binding = LayoutPollQuizOptionsItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return OptionViewHolder(binding,::getItem, ::selectOnlyCurrentOption, refreshSubmitButton)
+        return OptionViewHolder(binding,
+            ::getItem,
+            ::selectRadioOption,
+            ::selectCheckboxOption,
+            )
     }
 
     override fun onBindViewHolder(holder: OptionViewHolder, position: Int) {
@@ -43,13 +51,17 @@ class OptionsListAdapter : ListAdapter<Option, OptionViewHolder>(DIFFUTIL_CALLBA
         // Put the cursor in the edittext as it's created.
         holder.binding.text.requestFocus()
         holder.binding.text.hint = "Option ${position+1}"
-        holder.binding.text.addTextChangedListener(object : TextWatcher {
+        holder.binding.text.addTextChangedListener(
+            object : TextWatcher {
             override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
 
             }
 
             override fun onTextChanged(text: CharSequence?, p1: Int, p2: Int, p3: Int) {
-                getItem(holder.bindingAdapterPosition).text = text.toString()
+                val text = text.toString()
+                onOptionTextChanged(holder.bindingAdapterPosition, text)
+                // Maybe this is not required? Might be too big to refresh.
+                getItem(holder.bindingAdapterPosition).text = text
             }
 
             override fun afterTextChanged(p0: Editable?) {
@@ -67,11 +79,19 @@ class OptionsListAdapter : ListAdapter<Option, OptionViewHolder>(DIFFUTIL_CALLBA
         refreshSubmitButton()
     }
 
-    private fun selectOnlyCurrentOption(position: Int) {
-        for ( i in 0 until currentList.size) {
+    private fun selectRadioOption(position: Int){
+        onSingleOptionSelected(position)
+        // TODO this might not be necessary
+        for (i in 0 until currentList.size) {
             getItem(i).isChecked = i == position
-            if(i != position)
+            if (i != position)
                 notifyItemChanged(i)
         }
+        refreshSubmitButton()
+    }
+    private fun selectCheckboxOption(position: Int, selected: Boolean) {
+        onMultipleOptionSelected(position, selected)
+        getItem(position).isChecked = selected
+        refreshSubmitButton()
     }
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionsListAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionsListAdapter.kt
@@ -4,11 +4,9 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.core.widget.addTextChangedListener
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import live.hms.roomkit.databinding.LayoutPollQuizOptionsItemBinding
-import live.hms.roomkit.databinding.LayoutPollQuizOptionsItemMultiChoiceBinding
 import live.hms.roomkit.ui.theme.setTheme
 import java.util.*
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionsListAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionsListAdapter.kt
@@ -20,6 +20,7 @@ class OptionsListAdapter : ListAdapter<Option, OptionViewHolder>(DIFFUTIL_CALLBA
     lateinit var onOptionTextChanged : (optionIndex : Int, text : String) -> Unit
     lateinit var onSingleOptionSelected : (optionIndex : Int) -> Unit
     lateinit var onMultipleOptionSelected : (optionIndex : Int, selected : Boolean) -> Unit
+    lateinit var deleteOption : (optionIndex : Int) -> Unit
 
 
     companion object {
@@ -40,6 +41,7 @@ class OptionsListAdapter : ListAdapter<Option, OptionViewHolder>(DIFFUTIL_CALLBA
             ::getItem,
             ::selectRadioOption,
             ::selectCheckboxOption,
+            deleteOption
             )
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionsListAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/OptionsListAdapter.kt
@@ -49,7 +49,7 @@ class OptionsListAdapter : ListAdapter<Option, OptionViewHolder>(DIFFUTIL_CALLBA
         holder.bind(getItem(position))
         holder.binding.setTheme()
         // Put the cursor in the edittext as it's created.
-        holder.binding.text.requestFocus()
+//        holder.binding.text.requestFocus() // TODO maybe required but it's not quite right anyway
         holder.binding.text.hint = "Option ${position+1}"
         holder.binding.text.addTextChangedListener(
             object : TextWatcher {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreation.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreation.kt
@@ -33,7 +33,7 @@ class PollQuestionCreation : Fragment() {
     val args: PollQuestionCreationArgs by navArgs()
     private val pollsViewModel: PollsViewModel by activityViewModels()
     private val meetingViewModel: MeetingViewModel by activityViewModels()
-    private val adapter by lazy { PollQuestionCreatorAdapter(args.isPoll) }
+    private val adapter by lazy { PollQuestionCreatorAdapter(args.isPoll, ::launchPoll) }
 
     private var binding by viewLifecycle<LayoutPollQuestionCreationBinding>()
 
@@ -61,6 +61,7 @@ class PollQuestionCreation : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         initOnBackPress()
         with(binding) {
+            heading.text = "${pollsViewModel.getPollsCreationInfo().pollTitle} ${if(pollsViewModel.isPoll()) "Poll" else "Quiz"}"
             backButton.setOnSingleClickListener { findNavController().popBackStack() }
             createdQuestionList.adapter = adapter
             createdQuestionList.layoutManager = LinearLayoutManager(requireContext())
@@ -69,22 +70,6 @@ class PollQuestionCreation : Fragment() {
             }
             createdQuestionList.addItemDecoration(divider)
 
-            adapter.isReady = { isReady ->
-                launchPollQuiz.isEnabled = isReady
-            }
-
-
-            launchPollQuiz.setOnSingleClickListener {
-                // Clear the UI
-                // start the data
-                meetingViewModel.startPoll(
-                    adapter.currentList,
-                    pollsViewModel.getPollsCreationInfo()
-                )
-                backButton.callOnClick()
-            }
-            // Will be enabled later.
-            launchPollQuiz.isEnabled = false
         }
     }
 
@@ -96,5 +81,15 @@ class PollQuestionCreation : Fragment() {
                     binding.backButton.callOnClick()
                 }
             })
+    }
+
+    private fun launchPoll() {
+        // Launch the poll
+        meetingViewModel.startPoll(
+            adapter.currentList,
+            pollsViewModel.getPollsCreationInfo()
+        )
+        // Go back
+        findNavController().popBackStack()
     }
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreation.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreation.kt
@@ -7,10 +7,14 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView.VERTICAL
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import live.hms.roomkit.R
 import live.hms.roomkit.databinding.LayoutPollQuestionCreationBinding
 import live.hms.roomkit.ui.meeting.MeetingViewModel
@@ -26,9 +30,10 @@ import live.hms.roomkit.util.viewLifecycle
  */
 class PollQuestionCreation : Fragment() {
 
+    val args: PollQuestionCreationArgs by navArgs()
     private val pollsViewModel: PollsViewModel by activityViewModels()
     private val meetingViewModel: MeetingViewModel by activityViewModels()
-    private val adapter = PollQuestionCreatorAdapter { pollsViewModel.isPoll() }
+    private val adapter by lazy { PollQuestionCreatorAdapter(args.isPoll) }
 
     private var binding by viewLifecycle<LayoutPollQuestionCreationBinding>()
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreation.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreation.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -66,7 +67,7 @@ class PollQuestionCreation : Fragment() {
             createdQuestionList.adapter = adapter
             createdQuestionList.layoutManager = LinearLayoutManager(requireContext())
             val divider = DividerItemDecoration(requireContext(), VERTICAL).apply {
-                setDrawable(binding.root.context.getDrawable(R.drawable.questions_divider)!!)
+                setDrawable(AppCompatResources.getDrawable(requireContext(), R.drawable.questions_divider)!!)
             }
             createdQuestionList.addItemDecoration(divider)
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -124,8 +124,8 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
                         .plus(newQuestionCreator)
                         .sortQuestions())
                 }
-            }
-        ) { position ->
+            },
+            deleteQuestion = { position ->
             val itemToDelete = getItem(position)
             // also every item after this should have its question number decremented.
             // also the overall count is reduced.
@@ -144,7 +144,20 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
                     it
             }
             submitList(newList)
-        }
+        },
+            updateSelection = { position, selections, options ->
+                val selectedItem : QuestionUi? = getItem(position)
+                if(selectedItem != null && selectedItem is QuestionUi.QuestionCreator)
+                {
+                    val newList = currentList.minus(selectedItem)
+                        .plus(selectedItem.copy(currentQuestion = selectedItem.currentQuestion.apply {
+                            this.selections = selections
+                            this.options = options ?: this.options
+                        }))
+                        .sortQuestions()
+                    submitList(newList)
+                }
+            })
     }
 
     override fun onBindViewHolder(holder: PollQuestionViewHolder<ViewBinding>, position: Int) {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -87,10 +87,29 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
         }, {position ->
             getItem(position) as QuestionUi.QuestionCreator
         },
-        launchPoll)
+        launchPoll,
         {
             position -> notifyItemChanged(position)
-        }
+        },
+            editQuestion = {
+                position ->
+                val questionToEdit = getItem(position)
+                val newQuestionCreator = when (questionToEdit.viewType) {
+                    2 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.SingleChoiceQuestion)
+                    1 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.MultiChoiceQuestion)
+                    else -> null
+                }
+                // Delete the item and add a new question creator.
+                if(newQuestionCreator != null) {
+                    // Remove the AddAnotherItem because the question creator is being added
+                    submitList(currentList.minus(setOf(questionToEdit, QuestionUi.AddAnotherItemView))
+                        .plus(newQuestionCreator)
+                        .sortQuestions())
+                }
+            },
+            deleteQuestion = {
+                position -> submitList(currentList.minus(getItem(position)))
+            })
     }
 
     override fun onBindViewHolder(holder: PollQuestionViewHolder<ViewBinding>, position: Int) {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -71,10 +71,11 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
             else -> null
         }
         return PollQuestionViewHolder(view!!,
-            saveInfo = {questionUi ->
+            saveInfo = {questionUi, questionInEditIndex ->
             val list = currentList
                 .filter { item -> item.viewType != 0 }
-                .plus(questionUi.apply { index = ++count })
+                // Either restore the question in edit index or add a new one
+                .plus(questionUi.apply { index = questionInEditIndex ?: ++count })
                 .plus(QuestionUi.AddAnotherItemView)
             submitList(list.sortQuestions())
             }, isPoll,
@@ -95,11 +96,12 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
                 position ->
                 val questionToEdit = getItem(position)
                 val newQuestionCreator = when (questionToEdit.viewType) {
-                    2 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.SingleChoiceQuestion)
-                    1 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.MultiChoiceQuestion)
+                    1 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.MultiChoiceQuestion, questionInEditIndex = questionToEdit.index)
+                    2 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.SingleChoiceQuestion, questionInEditIndex = questionToEdit.index)
                     else -> null
                 }
                 // Delete the item and add a new question creator.
+                // The index number is maintained via the question creator knowing it and sending it back.
                 if(newQuestionCreator != null) {
                     // Remove the AddAnotherItem because the question creator is being added
                     submitList(currentList.minus(setOf(questionToEdit, QuestionUi.AddAnotherItemView))

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -86,6 +86,9 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
             getItem(position) as QuestionUi.QuestionCreator
         },
         launchPoll)
+        {
+            position -> notifyItemChanged(position)
+        }
     }
 
     override fun onBindViewHolder(holder: PollQuestionViewHolder<ViewBinding>, position: Int) {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -122,8 +122,16 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
                 // Only the question types
                 item.viewType in 1..4
             }.isNotEmpty()
-        currentList.find { it.viewType == 6 }?.let {
-            (it as QuestionUi.LaunchButton).enabled = shouldEnableLaunchPollButton
+
+        currentList.find { it.viewType == 6 }?.let { launchButton ->
+            val shouldNotify = (launchButton as QuestionUi.LaunchButton).
+                enabled != shouldEnableLaunchPollButton
+
+            if(shouldNotify) {
+                submitList(currentList.filterNot { it.viewType == 6 }
+                    .plus(launchButton.copy(enabled = shouldEnableLaunchPollButton)))
+            }
+
         }
 
     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -108,7 +108,18 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
                 }
             },
             deleteQuestion = {
-                position -> submitList(currentList.minus(getItem(position)))
+                position ->
+                val itemToDelete = getItem(position)
+                // also every item after this should have its question number decremented.
+                val newList = currentList.minus(itemToDelete).map { if((it.viewType == 1 || it.viewType == 2) && it.index > itemToDelete.index) {
+                    it.index--
+                    it
+                } else
+                    it
+                }
+                // also the overall count is reduced.
+                count--
+                submitList(newList)
             })
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -69,18 +69,19 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
             6 -> LayoutLaunchPollButtonBinding.inflate(LayoutInflater.from(parent.context), parent, false)
             else -> null
         }
-        return PollQuestionViewHolder(view!!, {
+        return PollQuestionViewHolder(view!!,
+            saveInfo = {questionUi ->
             val list = currentList
                 .filter { item -> item.viewType != 0 }
-                .plus(it)
+                .plus(questionUi)
                 .plus(QuestionUi.AddAnotherItemView)
-            submitList(list)
+            submitList(list.sortQuestions())
             }, isPoll,
         {
             submitList(
                 listOf(QuestionUi.QuestionCreator())
                     .plus(currentList)
-                    .minus(QuestionUi.AddAnotherItemView)
+                    .minus(QuestionUi.AddAnotherItemView).sortQuestions()
             )
         }, {position ->
             getItem(position) as QuestionUi.QuestionCreator
@@ -132,7 +133,7 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
 
             if(shouldNotify) {
                 submitList(currentList.filterNot { it.viewType == 6 }
-                    .plus(launchButton.copy(enabled = shouldEnableLaunchPollButton)))
+                    .plus(launchButton.copy(enabled = shouldEnableLaunchPollButton)).sortQuestions())
             }
 
         }
@@ -148,3 +149,5 @@ internal sealed interface QuestionCreatorChangePayload {
     data class Options(val newOptions: List<Option>?) : QuestionCreatorChangePayload
 
 }
+
+fun List<QuestionUi>.sortQuestions() : List<QuestionUi>{ return sortedBy { it.getItemId() } }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -17,7 +17,7 @@ class PollQuestionCreatorAdapter(val isPoll: () -> Boolean) : ListAdapter<Questi
     var isReady : ((ready : Boolean) -> Unit)? = null
     init {
         // Adaptor begins with the question creation ui.
-        submitList(listOf(QuestionUi.QuestionCreator))
+        submitList(listOf(QuestionUi.QuestionCreator()))
     }
 
     companion object {
@@ -51,9 +51,9 @@ class PollQuestionCreatorAdapter(val isPoll: () -> Boolean) : ListAdapter<Questi
             5 -> LayoutAddMoreBinding.inflate(LayoutInflater.from(parent.context), parent, false)
             else -> null
         }
-        return PollQuestionViewHolder(view!!, { submitList(currentList.plus(it).minus(QuestionUi.QuestionCreator).plus(QuestionUi.AddAnotherItemView)) }, isPoll)
+        return PollQuestionViewHolder(view!!, { submitList(currentList.plus(it).minus(QuestionUi.QuestionCreator()).plus(QuestionUi.AddAnotherItemView)) }, isPoll)
         {
-            submitList(listOf(QuestionUi.QuestionCreator).plus(currentList).minus(QuestionUi.AddAnotherItemView))
+            submitList(listOf(QuestionUi.QuestionCreator()).plus(currentList).minus(QuestionUi.AddAnotherItemView))
         }
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -65,7 +65,7 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
                 //Multichoice question (remember to set the single choice text as well)
                 LayoutPollQuizOptionsItemMultiChoiceBinding.inflate(LayoutInflater.from(parent.context), parent, false)
             }
-            3,4 -> LayoutPollQuizItemShortAnswerBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+//            3,4 -> LayoutPollQuizItemShortAnswerBinding.inflate(LayoutInflater.from(parent.context), parent, false)
             5 -> LayoutAddMoreBinding.inflate(LayoutInflater.from(parent.context), parent, false)
             6 -> LayoutLaunchPollButtonBinding.inflate(LayoutInflater.from(parent.context), parent, false)
             else -> null

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -10,10 +10,6 @@ import live.hms.roomkit.databinding.LayoutPollQuestionCreationItemBinding
 import live.hms.roomkit.databinding.LayoutPollQuizItemShortAnswerBinding
 import live.hms.roomkit.databinding.LayoutPollQuizOptionsItemMultiChoiceBinding
 
-internal sealed interface QuestionCreatorChangePayload {
-    data class Options(val newOptions: List<Option>?) : QuestionCreatorChangePayload
-
-}
 class PollQuestionCreatorAdapter(private val isPoll : Boolean) : ListAdapter<QuestionUi, PollQuestionViewHolder<ViewBinding>>(
     DIFFUTIL_CALLBACK
 ) {
@@ -119,4 +115,9 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean) : ListAdapter<Que
             currentList.filterNot { item -> item is QuestionUi.QuestionCreator }.isNotEmpty()
         isReady?.invoke(questionAdded)
     }
+}
+
+internal sealed interface QuestionCreatorChangePayload {
+    data class Options(val newOptions: List<Option>?) : QuestionCreatorChangePayload
+
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -151,4 +151,6 @@ internal sealed interface QuestionCreatorChangePayload {
 
 }
 
-fun List<QuestionUi>.sortQuestions() : List<QuestionUi>{ return sortedBy { it.getItemId() } }
+fun List<QuestionUi>.sortQuestions() : List<QuestionUi>{
+    return sortedWith(compareBy(QuestionUi::getItemId))
+}

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -78,10 +78,11 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
                 .plus(questionUi.apply { index = questionInEditIndex ?: ++count })
                 .plus(QuestionUi.AddAnotherItemView)
             submitList(list.sortQuestions())
-            }, isPoll,
-        {
+            },
+            isPoll,
+        reAddQuestionCreator = {
             submitList(
-                listOf(QuestionUi.QuestionCreator())
+                listOf(QuestionUi.QuestionCreator(isPoll = isPoll))
                     .plus(currentList)
                     .minus(QuestionUi.AddAnotherItemView).sortQuestions()
             )
@@ -96,8 +97,12 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
                 position ->
                 val questionToEdit = getItem(position)
                 val newQuestionCreator = when (questionToEdit.viewType) {
-                    1 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.MultiChoiceQuestion, questionInEditIndex = questionToEdit.index)
-                    2 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.SingleChoiceQuestion, questionInEditIndex = questionToEdit.index)
+                    1 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.MultiChoiceQuestion,
+                        questionInEditIndex = questionToEdit.index,
+                        isPoll = isPoll)
+                    2 -> QuestionUi.QuestionCreator(currentQuestion = questionToEdit as QuestionUi.SingleChoiceQuestion,
+                        questionInEditIndex = questionToEdit.index,
+                        isPoll = isPoll)
                     else -> null
                 }
                 // Delete the item and add a new question creator.

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionCreatorAdapter.kt
@@ -15,6 +15,7 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
                                  private val launchPoll : () -> Unit) : ListAdapter<QuestionUi, PollQuestionViewHolder<ViewBinding>>(
     DIFFUTIL_CALLBACK
 ) {
+    var count = 0L
     init {
         // Adaptor begins with the question creation ui.
         submitList(listOf(
@@ -73,7 +74,7 @@ class PollQuestionCreatorAdapter(private val isPoll : Boolean,
             saveInfo = {questionUi ->
             val list = currentList
                 .filter { item -> item.viewType != 0 }
-                .plus(questionUi)
+                .plus(questionUi.apply { index = ++count })
                 .plus(QuestionUi.AddAnotherItemView)
             submitList(list.sortQuestions())
             }, isPoll,

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -266,6 +266,7 @@ class PollQuestionViewHolder<T : ViewBinding>(
 
     private fun bind(questionUi: QuestionUi.SingleChoiceQuestion) {
         with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding) {
+            applyTheme()
             questionTitle.text = questionUi.withTitle
             questionNumbering.text = "QUESTION ${questionUi.index} of something"
             val adapter = GroupieAdapter()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
+import com.xwray.groupie.GroupieAdapter
 import live.hms.roomkit.R
 import live.hms.roomkit.databinding.LayoutAddMoreBinding
 import live.hms.roomkit.databinding.LayoutLaunchPollButtonBinding
@@ -225,7 +226,9 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 askAQuestionEditText.requestFocus() // To clear it from all others like options
                 askAQuestionEditText.clearFocus()   // To clear it from even this
                 // Save the info
-                saveInfo(getItem(bindingAdapterPosition).currentQuestion)
+                saveInfo(getItem(bindingAdapterPosition).currentQuestion.apply{
+                    index = ++count
+                })
             }
         }
     }
@@ -252,13 +255,15 @@ class PollQuestionViewHolder<T : ViewBinding>(
     }
 
     private fun bind(questionUi: QuestionUi.MultiChoiceQuestion) {
-
         with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding) {
+            applyTheme()
             questionTitle.text = questionUi.withTitle
-            val adapter =
-                ArrayAdapter<String>(binding.root.context, android.R.layout.simple_list_item_1)
-//            options.layoutManager = LinearLayoutManager(binding.root.context)
-            adapter.addAll(questionUi.options)
+            questionNumbering.text = "QUESTION ${questionUi.index} of something"
+            val adapter = GroupieAdapter()
+            adapter.addAll(questionUi.options.map {
+                MultiChoiceQuestionOptionItem(questionUi, it)
+            })
+            options.layoutManager = LinearLayoutManager(binding.root.context)
             options.adapter = adapter
         }
     }
@@ -266,10 +271,12 @@ class PollQuestionViewHolder<T : ViewBinding>(
     private fun bind(questionUi: QuestionUi.SingleChoiceQuestion) {
         with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding) {
             questionTitle.text = questionUi.withTitle
-            val adapter =
-                ArrayAdapter<String>(binding.root.context, android.R.layout.simple_list_item_1)
-//            options.layoutManager = LinearLayoutManager(binding.root.context)
-            adapter.addAll(questionUi.options)
+            questionNumbering.text = "QUESTION ${questionUi.index} of something"
+            val adapter = GroupieAdapter()
+            adapter.addAll(questionUi.options.map {
+                MultiChoiceQuestionOptionItem(questionUi, it)
+            })
+            options.layoutManager = LinearLayoutManager(binding.root.context)
             options.adapter = adapter
         }
     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -9,7 +9,6 @@ import android.widget.AdapterView.OnItemSelectedListener
 import android.widget.ArrayAdapter
 import android.widget.Spinner
 import android.widget.TextView
-import android.widget.Toast
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -25,68 +24,6 @@ import live.hms.roomkit.ui.theme.saveButtonEnabled
 import live.hms.roomkit.util.setOnSingleClickListener
 
 private var count: Long = 0
-
-sealed class QuestionUi(
-    open var index: Long,
-    open val viewType: Int,
-    open var requiredToAnswer: Boolean
-) {
-    // Makes the creator UI show up first.
-    data class QuestionCreator(var currentQuestion: ChoiceQuestions = SingleChoiceQuestion(),
-                               var isPoll : Boolean = true
-    ) : QuestionUi(0, 0, false)
-
-    sealed class ChoiceQuestions(
-        override var index: Long,
-        override val viewType: Int,
-        override var requiredToAnswer: Boolean,
-        open var withTitle: String = "",
-        open var options: List<String> = emptyList(),
-        open var selections : List<Int> = emptyList()
-    ) : QuestionUi(index, viewType, requiredToAnswer){
-        open fun isValid(isPoll : Boolean) : Boolean {
-            return withTitle.isNotEmpty() &&
-                    options.isNotEmpty() &&
-                    options.none { it.isEmpty()}
-        }
-    }
-
-    // Actual questions that might be asked.
-    data class MultiChoiceQuestion(
-        override var withTitle: String = "",
-        override var options: List<String> = listOf("",""),
-        var correctOptionIndex: List<Int>? = null,
-        override var index: Long = -1,
-        override var requiredToAnswer: Boolean = false
-    ) : ChoiceQuestions(index, 1, requiredToAnswer) {
-        override fun isValid(isPoll : Boolean): Boolean {
-            return super.isValid(isPoll) && (isPoll || correctOptionIndex != null)
-        }
-    }
-
-    data class SingleChoiceQuestion(
-        override var withTitle: String = "",
-        override var options: List<String> = listOf("",""),
-        var correctOptionIndex: Int? = null,
-        override var index: Long = -1,
-        override var requiredToAnswer: Boolean = false
-    ) : ChoiceQuestions(index, 2, requiredToAnswer) {
-        override fun isValid(isPoll : Boolean): Boolean {
-            return super.isValid(isPoll) && (isPoll || correctOptionIndex != null)
-        }
-    }
-
-    data class LongAnswer(
-        val text: String, override var index: Long, override var requiredToAnswer: Boolean
-    ) : QuestionUi(index, 3, requiredToAnswer)
-
-    data class ShortAnswer(
-        val text: String, override var index: Long, override var requiredToAnswer: Boolean
-    ) : QuestionUi(index, 4, requiredToAnswer)
-
-    object AddAnotherItemView : QuestionUi(-1, 5, false)
-    object LaunchButton
-}
 
 class PollQuestionViewHolder<T : ViewBinding>(
     val binding: T,

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -26,8 +26,6 @@ import live.hms.roomkit.ui.theme.saveButtonDisabled
 import live.hms.roomkit.ui.theme.saveButtonEnabled
 import live.hms.roomkit.util.setOnSingleClickListener
 
-private var count: Long = 0
-
 class PollQuestionViewHolder<T : ViewBinding>(
     val binding: T,
     val saveInfo: (questionUi: QuestionUi) -> Unit,
@@ -226,9 +224,7 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 askAQuestionEditText.requestFocus() // To clear it from all others like options
                 askAQuestionEditText.clearFocus()   // To clear it from even this
                 // Save the info
-                saveInfo(getItem(bindingAdapterPosition).currentQuestion.apply{
-                    index = ++count
-                })
+                saveInfo(getItem(bindingAdapterPosition).currentQuestion)
             }
         }
     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -24,6 +24,8 @@ import live.hms.roomkit.databinding.LayoutPollQuizItemShortAnswerBinding
 import live.hms.roomkit.databinding.LayoutPollQuizOptionsItemMultiChoiceBinding
 import live.hms.roomkit.setOnSingleClickListener
 import live.hms.roomkit.ui.theme.applyTheme
+import live.hms.roomkit.ui.theme.buttonDisabled
+import live.hms.roomkit.ui.theme.buttonEnabled
 import live.hms.roomkit.ui.theme.saveButtonDisabled
 import live.hms.roomkit.ui.theme.saveButtonEnabled
 import live.hms.roomkit.util.setOnSingleClickListener
@@ -70,9 +72,9 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 "Launch Quiz"
 
             if (button.enabled)
-                saveButtonEnabled()
+                buttonEnabled()
             else
-                saveButtonDisabled()
+                buttonDisabled()
 
             setOnSingleClickListener {
                 launchPoll()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -104,6 +104,7 @@ class PollQuestionViewHolder<T : ViewBinding>(
             notRequiredToAnswer.setOnCheckedChangeListener { _, b ->
                 getItem(bindingAdapterPosition).currentQuestion.requiredToAnswer = b
             }
+            binding.askAQuestionEditText.setText(questionUi.currentQuestion.withTitle)
             binding.askAQuestionEditText.addTextChangedListener(object : TextWatcher {
                 override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
 
@@ -152,6 +153,9 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 it.deleteOption = { position ->
                     val question =
                         getItem(bindingAdapterPosition).currentQuestion
+                    // Remove the option from the selections (answers) if it was present
+                    question.selections = question.selections.minus(position)
+                    // Remove the option
                     question.options = question.options.minus(question.options[position])
                     refresh(bindingAdapterPosition)
                 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -147,6 +147,12 @@ class PollQuestionViewHolder<T : ViewBinding>(
                         question.selections.minus(position).sorted()
                     validateSaveButtonEnabledState(getItem(bindingAdapterPosition), binding.saveButton)
                 }
+                it.deleteOption = { position ->
+                    val question =
+                        getItem(position).currentQuestion
+                    question.options = question.options.minus(question.options[position])
+                    refresh(bindingAdapterPosition)
+                }
             }
             optionsAdapter.submitList(QuestionToOptions().questionToOptions(questionUi.currentQuestion, questionUi.isPoll))
             optionsListView.adapter = optionsAdapter
@@ -208,11 +214,6 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 question.options = question.options.plus("")
                 refresh(bindingAdapterPosition)
                 // The same item could refresh just fine, only other items need specific invocationx
-            }
-            deleteOptionTrashButton.setOnSingleClickListener {
-                val question =
-                    getItem(bindingAdapterPosition).currentQuestion as QuestionUi.ChoiceQuestions
-                question.options = question.options.dropLast(1)
             }
 
             saveButton.saveButtonDisabled()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -2,12 +2,9 @@ package live.hms.roomkit.ui.polls
 
 import android.text.Editable
 import android.text.TextWatcher
-import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
-import android.widget.ArrayAdapter
 import android.widget.Spinner
 import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
@@ -20,7 +17,6 @@ import live.hms.roomkit.R
 import live.hms.roomkit.databinding.LayoutAddMoreBinding
 import live.hms.roomkit.databinding.LayoutLaunchPollButtonBinding
 import live.hms.roomkit.databinding.LayoutPollQuestionCreationItemBinding
-import live.hms.roomkit.databinding.LayoutPollQuizItemShortAnswerBinding
 import live.hms.roomkit.databinding.LayoutPollQuizOptionsItemMultiChoiceBinding
 import live.hms.roomkit.setOnSingleClickListener
 import live.hms.roomkit.ui.theme.applyTheme
@@ -28,18 +24,17 @@ import live.hms.roomkit.ui.theme.buttonDisabled
 import live.hms.roomkit.ui.theme.buttonEnabled
 import live.hms.roomkit.ui.theme.saveButtonDisabled
 import live.hms.roomkit.ui.theme.saveButtonEnabled
-import live.hms.roomkit.util.setOnSingleClickListener
 
 class PollQuestionViewHolder<T : ViewBinding>(
     val binding: T,
-    val saveInfo: (questionUi: QuestionUi, questionInEditIndex : Long?) -> Unit,
+    val saveInfo: (questionUi: QuestionUi, questionInEditIndex: Long?) -> Unit,
     val isPoll: Boolean,
     val reAddQuestionCreator: () -> Unit,
     val getItem: (position: Int) -> QuestionUi.QuestionCreator,
-    val launchPoll : () -> Unit,
-    val refresh : (position : Int) -> Unit,
-    val editQuestion : (position : Int) -> Unit,
-    val deleteQuestion : (position : Int) -> Unit
+    val launchPoll: () -> Unit,
+    val refresh: (position: Int) -> Unit,
+    val editQuestion: (position: Int) -> Unit,
+    val deleteQuestion: (position: Int) -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
     private val TAG = "PollQuestionViewHolder"
 
@@ -276,7 +271,7 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 deleteQuestion(bindingAdapterPosition)
             }
             questionTitle.text = questionUi.withTitle
-            questionNumbering.text = "QUESTION ${questionUi.index} of something: ${if(questionUi is QuestionUi.SingleChoiceQuestion) "SINGLE CHOICE" else "MULTIPLE CHOICE"}"
+            questionNumbering.text = "QUESTION ${questionUi.index} of ${questionUi.totalQuestions}: ${if(questionUi is QuestionUi.SingleChoiceQuestion) "SINGLE CHOICE" else "MULTIPLE CHOICE"}"
             val adapter = GroupieAdapter()
             adapter.addAll(questionUi.options.map {
                 MultiChoiceQuestionOptionItem(questionUi, it)

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -10,6 +10,7 @@ import android.widget.AdapterView.OnItemSelectedListener
 import android.widget.ArrayAdapter
 import android.widget.Spinner
 import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -41,12 +42,11 @@ class PollQuestionViewHolder<T : ViewBinding>(
         when (questionUi) {
             is QuestionUi.QuestionCreator -> bind(questionUi)
             is QuestionUi.LongAnswer -> bind(questionUi)
-            is QuestionUi.MultiChoiceQuestion -> bind(questionUi)
             is QuestionUi.ShortAnswer -> bind(questionUi)
-            is QuestionUi.SingleChoiceQuestion -> bind(questionUi)
             is QuestionUi.AddAnotherItemView -> bind(questionUi)
             is QuestionUi.LaunchButton -> bind(questionUi)
-            is QuestionUi.ChoiceQuestions -> TODO()
+            is QuestionUi.ChoiceQuestions -> bind(questionUi)
+
         }
     }
 
@@ -250,33 +250,38 @@ class PollQuestionViewHolder<T : ViewBinding>(
         else saveButton.saveButtonDisabled()
     }
 
-    private fun bind(questionUi: QuestionUi.MultiChoiceQuestion) {
+    private fun bind(questionUi: QuestionUi.ChoiceQuestions) {
         with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding) {
             applyTheme()
             questionTitle.text = questionUi.withTitle
-            questionNumbering.text = "QUESTION ${questionUi.index} of something"
+            questionNumbering.text = "QUESTION ${questionUi.index} of something: ${if(questionUi is QuestionUi.SingleChoiceQuestion) "SINGLE CHOICE" else "MULTIPLE CHOICE"}"
             val adapter = GroupieAdapter()
             adapter.addAll(questionUi.options.map {
                 MultiChoiceQuestionOptionItem(questionUi, it)
             })
+
+            val divider = DividerItemDecoration(binding.root.context, RecyclerView.VERTICAL).apply {
+                setDrawable(AppCompatResources.getDrawable(binding.root.context, R.drawable.polls_creation_divider)!!)
+            }
+            options.addItemDecoration(divider)
             options.layoutManager = LinearLayoutManager(binding.root.context)
             options.adapter = adapter
         }
     }
 
-    private fun bind(questionUi: QuestionUi.SingleChoiceQuestion) {
-        with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding) {
-            applyTheme()
-            questionTitle.text = questionUi.withTitle
-            questionNumbering.text = "QUESTION ${questionUi.index} of something"
-            val adapter = GroupieAdapter()
-            adapter.addAll(questionUi.options.map {
-                MultiChoiceQuestionOptionItem(questionUi, it)
-            })
-            options.layoutManager = LinearLayoutManager(binding.root.context)
-            options.adapter = adapter
-        }
-    }
+//    private fun bind(questionUi: QuestionUi.SingleChoiceQuestion) {
+//        with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding) {
+//            applyTheme()
+//            questionTitle.text = questionUi.withTitle
+//            questionNumbering.text = "QUESTION ${questionUi.index} of something"
+//            val adapter = GroupieAdapter()
+//            adapter.addAll(questionUi.options.map {
+//                MultiChoiceQuestionOptionItem(questionUi, it)
+//            })
+//            options.layoutManager = LinearLayoutManager(binding.root.context)
+//            options.adapter = adapter
+//        }
+//    }
 
     private fun bind(questionUi: QuestionUi.ShortAnswer) {
         with(binding as LayoutPollQuizItemShortAnswerBinding) {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -157,6 +157,7 @@ class PollQuestionViewHolder<T : ViewBinding>(
                     question.selections = question.selections.minus(position)
                     // Remove the option
                     question.options = question.options.minus(question.options[position])
+                    validateSaveButtonEnabledState(getItem(bindingAdapterPosition), binding.saveButton)
                     refresh(bindingAdapterPosition)
                 }
             }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -30,7 +30,7 @@ import live.hms.roomkit.util.setOnSingleClickListener
 
 class PollQuestionViewHolder<T : ViewBinding>(
     val binding: T,
-    val saveInfo: (questionUi: QuestionUi) -> Unit,
+    val saveInfo: (questionUi: QuestionUi, questionInEditIndex : Long?) -> Unit,
     val isPoll: Boolean,
     val reAddQuestionCreator: () -> Unit,
     val getItem: (position: Int) -> QuestionUi.QuestionCreator,
@@ -232,7 +232,8 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 askAQuestionEditText.requestFocus() // To clear it from all others like options
                 askAQuestionEditText.clearFocus()   // To clear it from even this
                 // Save the info
-                saveInfo(getItem(bindingAdapterPosition).currentQuestion)
+                val questionCreatorInfo = getItem(bindingAdapterPosition)
+                saveInfo(questionCreatorInfo.currentQuestion, questionCreatorInfo.questionInEditIndex)
             }
         }
     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -3,6 +3,7 @@ package live.hms.roomkit.ui.polls
 import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
@@ -15,6 +16,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
 import live.hms.roomkit.R
 import live.hms.roomkit.databinding.LayoutAddMoreBinding
+import live.hms.roomkit.databinding.LayoutLaunchPollButtonBinding
 import live.hms.roomkit.databinding.LayoutPollQuestionCreationItemBinding
 import live.hms.roomkit.databinding.LayoutPollQuizItemShortAnswerBinding
 import live.hms.roomkit.databinding.LayoutPollQuizOptionsItemMultiChoiceBinding
@@ -30,7 +32,8 @@ class PollQuestionViewHolder<T : ViewBinding>(
     val saveInfo: (questionUi: QuestionUi) -> Unit,
     val isPoll: Boolean,
     val reAddQuestionCreator: () -> Unit,
-    val getItem: (position: Int) -> QuestionUi.QuestionCreator
+    val getItem: (position: Int) -> QuestionUi.QuestionCreator,
+    val launchPoll : () -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
     private val TAG = "PollQuestionViewHolder"
 
@@ -42,6 +45,7 @@ class PollQuestionViewHolder<T : ViewBinding>(
             is QuestionUi.ShortAnswer -> bind(questionUi)
             is QuestionUi.SingleChoiceQuestion -> bind(questionUi)
             is QuestionUi.AddAnotherItemView -> bind(questionUi)
+            is QuestionUi.LaunchButton -> bind(questionUi)
             is QuestionUi.ChoiceQuestions -> TODO()
         }
     }
@@ -52,6 +56,24 @@ class PollQuestionViewHolder<T : ViewBinding>(
             return
         with(binding as LayoutPollQuestionCreationItemBinding) {
             (optionsListView.adapter as OptionsListAdapter).submitList(options.newOptions)
+        }
+    }
+
+    private fun bind(button : QuestionUi.LaunchButton) {
+        with((binding as LayoutLaunchPollButtonBinding).launchPollQuiz) {
+            text = if(button.isPoll)
+                "Launch Poll"
+            else
+                "Launch Quiz"
+
+            if (button.enabled)
+                saveButtonEnabled()
+            else
+                saveButtonDisabled()
+
+            setOnSingleClickListener {
+                launchPoll()
+            }
         }
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -260,10 +260,12 @@ class PollQuestionViewHolder<T : ViewBinding>(
 
             saveButton.saveButtonDisabled()
             saveButton.setOnClickListener {
-                // Every edit text has to be disabled at this point.
-                // The one for the title.
-                // TODO The ones for options
-
+                // Every edit text has to have its focus cleared at this point otherwise
+                // it will crash with a java.lang.IllegalArgumentException: parameter must be a descendant of this view
+                //                                                                                                    	at android.view.ViewGroup.offsetRectBetweenParentAndChild(ViewGroup.java:6295).
+                //  The one for the title.
+                askAQuestionEditText.requestFocus() // To clear it from all others like options
+                askAQuestionEditText.clearFocus()   // To clear it from even this
                 // Save the info
                 saveInfo(getItem(bindingAdapterPosition).currentQuestion)
             }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -149,7 +149,7 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 }
                 it.deleteOption = { position ->
                     val question =
-                        getItem(position).currentQuestion
+                        getItem(bindingAdapterPosition).currentQuestion
                     question.options = question.options.minus(question.options[position])
                     refresh(bindingAdapterPosition)
                 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -206,6 +206,7 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 val question =
                     getItem(bindingAdapterPosition).currentQuestion as QuestionUi.ChoiceQuestions
                 question.options = question.options.plus("")
+                refresh(bindingAdapterPosition)
                 // The same item could refresh just fine, only other items need specific invocationx
             }
             deleteOptionTrashButton.setOnSingleClickListener {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -1,5 +1,7 @@
 package live.hms.roomkit.ui.polls
 
+import android.text.Editable
+import android.text.TextWatcher
 import android.util.Log
 import android.view.View
 import android.widget.AdapterView
@@ -7,6 +9,7 @@ import android.widget.AdapterView.OnItemSelectedListener
 import android.widget.ArrayAdapter
 import android.widget.Spinner
 import android.widget.TextView
+import android.widget.Toast
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -21,42 +24,97 @@ import live.hms.roomkit.ui.theme.saveButtonDisabled
 import live.hms.roomkit.ui.theme.saveButtonEnabled
 import live.hms.roomkit.util.setOnSingleClickListener
 
-private var count : Long = 0
-sealed class QuestionUi(open val index : Long, open val viewType : Int, open val requiredToAnswer : Boolean){
+private var count: Long = 0
+
+sealed class QuestionUi(
+    open var index: Long,
+    open val viewType: Int,
+    open var requiredToAnswer: Boolean
+) {
     // Makes the creator UI show up first.
-    data class QuestionCreator(var questionUi: QuestionUi? = null) : QuestionUi(0, 0, false)
+    data class QuestionCreator(var currentQuestion: ChoiceQuestions = SingleChoiceQuestion(),
+                               var isPoll : Boolean = true
+    ) : QuestionUi(0, 0, false)
+
+    sealed class ChoiceQuestions(
+        override var index: Long,
+        override val viewType: Int,
+        override var requiredToAnswer: Boolean,
+        open var withTitle: String = "",
+        open var options: List<String> = emptyList(),
+        open var selections : List<Int> = emptyList()
+    ) : QuestionUi(index, viewType, requiredToAnswer){
+        open fun isValid(isPoll : Boolean) : Boolean {
+            return withTitle.isNotEmpty() &&
+                    options.isNotEmpty() &&
+                    options.none { it.isEmpty()}
+        }
+    }
 
     // Actual questions that might be asked.
-    data class MultiChoiceQuestion(val withTitle: String, val options: List<String>, val correctOptionIndex: List<Int>?, override val index : Long,
-                                   override val requiredToAnswer: Boolean) : QuestionUi(index, 1, requiredToAnswer)
-    data class SingleChoiceQuestion(val withTitle: String,
-                                    val options: List<String>,
-                                    val correctOptionIndex: Int?,
-                                    override val index : Long,
-                                    override val requiredToAnswer: Boolean) : QuestionUi(index, 2, requiredToAnswer)
-    data class LongAnswer(val text : String, override val index: Long,
-                          override val requiredToAnswer: Boolean) : QuestionUi(index, 3, requiredToAnswer)
-    data class ShortAnswer(val text : String, override val index: Long,
-                           override val requiredToAnswer: Boolean) : QuestionUi(index, 4, requiredToAnswer)
+    data class MultiChoiceQuestion(
+        override var withTitle: String = "",
+        override var options: List<String> = listOf("",""),
+        var correctOptionIndex: List<Int>? = null,
+        override var index: Long = -1,
+        override var requiredToAnswer: Boolean = false
+    ) : ChoiceQuestions(index, 1, requiredToAnswer) {
+        override fun isValid(isPoll : Boolean): Boolean {
+            return super.isValid(isPoll) && (isPoll || correctOptionIndex != null)
+        }
+    }
+
+    data class SingleChoiceQuestion(
+        override var withTitle: String = "",
+        override var options: List<String> = listOf("",""),
+        var correctOptionIndex: Int? = null,
+        override var index: Long = -1,
+        override var requiredToAnswer: Boolean = false
+    ) : ChoiceQuestions(index, 2, requiredToAnswer) {
+        override fun isValid(isPoll : Boolean): Boolean {
+            return super.isValid(isPoll) && (isPoll || correctOptionIndex != null)
+        }
+    }
+
+    data class LongAnswer(
+        val text: String, override var index: Long, override var requiredToAnswer: Boolean
+    ) : QuestionUi(index, 3, requiredToAnswer)
+
+    data class ShortAnswer(
+        val text: String, override var index: Long, override var requiredToAnswer: Boolean
+    ) : QuestionUi(index, 4, requiredToAnswer)
+
     object AddAnotherItemView : QuestionUi(-1, 5, false)
     object LaunchButton
 }
 
-class PollQuestionViewHolder<T : ViewBinding>(val binding: T,
-                                              val saveInfo : (questionUi: QuestionUi) -> Unit,
-    val isPoll : () -> Boolean,
-                                              val reAddQuestionCreator: () -> Unit,
+class PollQuestionViewHolder<T : ViewBinding>(
+    val binding: T,
+    val saveInfo: (questionUi: QuestionUi) -> Unit,
+    val isPoll: Boolean,
+    val reAddQuestionCreator: () -> Unit,
+    val getItem: (position: Int) -> QuestionUi.QuestionCreator
 ) : RecyclerView.ViewHolder(binding.root) {
     private val TAG = "PollQuestionViewHolder"
 
     fun bind(questionUi: QuestionUi) {
-        when(questionUi) {
-            is QuestionUi.QuestionCreator -> bind(QuestionUi.QuestionCreator())
+        when (questionUi) {
+            is QuestionUi.QuestionCreator -> bind(questionUi)
             is QuestionUi.LongAnswer -> bind(questionUi)
             is QuestionUi.MultiChoiceQuestion -> bind(questionUi)
             is QuestionUi.ShortAnswer -> bind(questionUi)
             is QuestionUi.SingleChoiceQuestion -> bind(questionUi)
             is QuestionUi.AddAnotherItemView -> bind(questionUi)
+            is QuestionUi.ChoiceQuestions -> TODO()
+        }
+    }
+
+    internal fun payloadUpdate(options : QuestionCreatorChangePayload.Options) {
+        // So since it was called in here, the binding must be QuestionCreatorBinding.
+        if(options.newOptions == null)
+            return
+        with(binding as LayoutPollQuestionCreationItemBinding) {
+            (optionsListView.adapter as OptionsListAdapter).submitList(options.newOptions)
         }
     }
 
@@ -68,52 +126,119 @@ class PollQuestionViewHolder<T : ViewBinding>(val binding: T,
             reAddQuestionCreator()
         }
     }
+
+    private fun getTitle(binding: LayoutPollQuestionCreationItemBinding): String = with(binding) {
+        askAQuestionEditText.text.toString()
+    }
+
+    private fun getSelectedQuestionType(binding: LayoutPollQuestionCreationItemBinding) =
+        with(binding) {
+            questionTypeSpinner.selectedItemPosition
+        }
+
     private fun bind(questionUi: QuestionUi.QuestionCreator) {
         with(binding as LayoutPollQuestionCreationItemBinding) {
             binding.applyTheme()
-            val requiredToAnswer = !notRequiredToAnswer.isChecked
-            val optionsAdapter = OptionsListAdapter().also {
-                it.refreshSubmitButton = { validateSaveButtonEnabledState(it, binding.saveButton) }
+            notRequiredToAnswer.setOnCheckedChangeListener { _, b ->
+                getItem(bindingAdapterPosition).currentQuestion.requiredToAnswer = b
             }
+            binding.askAQuestionEditText.addTextChangedListener(object : TextWatcher {
+                override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+
+                }
+
+                override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                    getItem(bindingAdapterPosition).currentQuestion.withTitle = p0.toString()
+                }
+
+                override fun afterTextChanged(p0: Editable?) {
+                    validateSaveButtonEnabledState(getItem(bindingAdapterPosition), binding.saveButton)
+                }
+
+            })
+            val optionsAdapter = OptionsListAdapter().also {
+                it.refreshSubmitButton = { validateSaveButtonEnabledState(getItem(bindingAdapterPosition), binding.saveButton) }
+                it.onOptionTextChanged = { optionIndex, changedText ->
+                    val question =
+                        getItem(bindingAdapterPosition).currentQuestion as QuestionUi.ChoiceQuestions
+                    val changedList: List<String> = question.options.toMutableList().apply {
+                        this[optionIndex] = changedText
+                    }
+                    question.options = changedList
+                    validateSaveButtonEnabledState(getItem(bindingAdapterPosition), binding.saveButton)
+                }
+                it.onSingleOptionSelected = { position ->
+                    val question =
+                        getItem(bindingAdapterPosition).currentQuestion as QuestionUi.SingleChoiceQuestion
+                    // This can't be right.... also we don't have any variable for selected
+                    //  but not answered.
+                    // This is in fact the perfect thing to create a model class for
+                    // Though that model will have to be stored....
+                    question.selections = listOf(position)
+                    validateSaveButtonEnabledState(getItem(bindingAdapterPosition), binding.saveButton)
+                }
+                it.onMultipleOptionSelected = { position, selected ->
+                    val question =
+                        getItem(bindingAdapterPosition).currentQuestion as QuestionUi.MultiChoiceQuestion
+
+                    question.selections = if(selected)
+                         question.selections.plus(position).sorted()
+                    else
+                        question.selections.minus(position).sorted()
+                    validateSaveButtonEnabledState(getItem(bindingAdapterPosition), binding.saveButton)
+                }
+            }
+            optionsAdapter.submitList(QuestionToOptions().questionToOptions(questionUi.currentQuestion, questionUi.isPoll))
             optionsListView.adapter = optionsAdapter
             optionsListView.layoutManager = LinearLayoutManager(binding.root.context)
-            val divider =
-                DividerItemDecoration(binding.root.context, RecyclerView.VERTICAL).apply {
-                    setDrawable(binding.root.context.getDrawable(R.drawable.polls_creation_divider)!!)
-                }
-            if(isPoll())
-                optionsListView.addItemDecoration(divider)
+            val divider = DividerItemDecoration(binding.root.context, RecyclerView.VERTICAL).apply {
+                setDrawable(binding.root.context.getDrawable(R.drawable.polls_creation_divider)!!)
+            }
+            if (isPoll) optionsListView.addItemDecoration(divider)
             questionTypeSpinner.onItemSelectedListener = object : OnItemSelectedListener {
                 override fun onItemSelected(
-                    parent: AdapterView<*>?,
-                    view: View?,
-                    position: Int,
-                    id: Long
+                    parent: AdapterView<*>?, view: View?, position: Int, id: Long
                 ) {
-
                     // Reset options whenever a question type is selected
                     // Add two empty options
-                    val isPoll = isPoll()
-                    optionsAdapter.submitList(listOf(
-                        Option("", if(isPoll) null else isMultiOptionQuestionCreation(questionTypeSpinner)),
-                        Option("", if(isPoll) null else isMultiOptionQuestionCreation(questionTypeSpinner))
-                    ))
+
+                    val isMultiChoice = isMultiOptionQuestionCreation(questionTypeSpinner)
+                    val startingOptions = listOf("", "")
+//                        listOf(
+//                        Option("", if(isPoll) null else isMultiChoice),
+//                        Option("", if(isPoll) null else isMultiChoice)
+//                    )
+
+                    // Three different option types.
+                    // 1. Poll/Quiz
+                    // 2. Single choice question
+                    // 3. Multi choice
+//                    if(option.isChecked)
+//                        selectedIndices.add(index)
+
+                    getItem(bindingAdapterPosition).apply {
+                        currentQuestion = if (isMultiChoice) {
+                            QuestionUi.MultiChoiceQuestion(getTitle(binding))
+                        } else {
+                            QuestionUi.SingleChoiceQuestion(getTitle(binding))
+                        }
+                    }
 
                     // If short/long answer hide the options else show them
-                    val multiOptionVisibility = if(position > 1) View.GONE else View.VISIBLE
+                    val multiOptionVisibility = if (position > 1) View.GONE else View.VISIBLE
                     addAnOptionTextView.visibility = multiOptionVisibility
                     optionsListView.visibility = multiOptionVisibility
                     optionsHeading.visibility = multiOptionVisibility
-                    optionsHeading.text = if(position == 0 ) {
+                    optionsHeading.text = if (position == 0) {
                         binding.root.context.getString(R.string.single_choice_text)
-                    } else if(position == 1 ){
+                    } else if (position == 1) {
                         binding.root.context.getString(R.string.multi_choice_text)
                     } else {
                         ""
                     }
 
                     // Only the UI might need to be toggled
-                    Log.d(TAG,"Toggle UI")
+                    Log.d(TAG, "Toggle UI")
                 }
 
                 override fun onNothingSelected(parent: AdapterView<*>?) {
@@ -122,58 +247,25 @@ class PollQuestionViewHolder<T : ViewBinding>(val binding: T,
 
             }
             addAnOptionTextView.setOnSingleClickListener {
-                val showCheckBox = isMultiOptionQuestionCreation(questionTypeSpinner)
-                addNewOption(optionsAdapter, showCheckBox)
+                val question =
+                    getItem(bindingAdapterPosition).currentQuestion as QuestionUi.ChoiceQuestions
+                question.options = question.options.plus("")
+                // The same item could refresh just fine, only other items need specific invocationx
             }
             deleteOptionTrashButton.setOnSingleClickListener {
-                // Delete the last option when delete is clicked.
-                optionsAdapter.submitList(optionsAdapter.currentList.dropLast(1))
+                val question =
+                    getItem(bindingAdapterPosition).currentQuestion as QuestionUi.ChoiceQuestions
+                question.options = question.options.dropLast(1)
             }
+
             saveButton.saveButtonDisabled()
             saveButton.setOnClickListener {
-                saveButton.saveButtonDisabled()
-                val title = askAQuestionEditText.text.toString()
-                val newQuestionUi = when(questionTypeSpinner.selectedItemPosition){
-                    // single, multi, short, long
-                    0,1 -> {
-                        val items = (optionsListView.adapter as OptionsListAdapter).currentList.map { it.text }
-                        if(questionTypeSpinner.selectedItemPosition == 0) {
-                            val selectedIndex = optionsAdapter.currentList.indexOfFirst { it.isChecked }
-                            val selected = if(selectedIndex == -1)
-                                null
-                            else
-                                selectedIndex
-                            QuestionUi.SingleChoiceQuestion(
-                                title,
-                                items,
-                                selected,
-                                count++,
-                                requiredToAnswer
-                            )
-                        }
-                        else {
-                            val selectedIndices = mutableListOf<Int>()
-                            optionsAdapter.currentList.forEachIndexed { index, option ->
-                                if(option.isChecked)
-                                    selectedIndices.add(index)
-                            }
-                            QuestionUi.MultiChoiceQuestion(
-                                title,
-                                items,
-                                selectedIndices,
-                                count++,
-                                requiredToAnswer
-                            )
-                        }
-                    }
-                    2 -> QuestionUi.ShortAnswer(title, count++, requiredToAnswer)
-                    3 -> QuestionUi.LongAnswer(title, count++, requiredToAnswer)
-                    else -> null
-                }
-                // Reset the UI
-                askAQuestionEditText.setText("")
+                // Every edit text has to be disabled at this point.
+                // The one for the title.
+                // TODO The ones for options
+
                 // Save the info
-                saveInfo(newQuestionUi!!)
+                saveInfo(getItem(bindingAdapterPosition).currentQuestion)
             }
         }
     }
@@ -182,42 +274,23 @@ class PollQuestionViewHolder<T : ViewBinding>(val binding: T,
         return questionTypeSpinner.selectedItemPosition == 1
     }
 
-    private fun addNewOption(optionsAdapter: OptionsListAdapter, showCheckBox: Boolean) {
-        optionsAdapter.submitList(optionsAdapter.currentList.plus(Option("", showCheckBox)))
-    }
-
     private fun validateSaveButtonEnabledState(
-        optionsAdapter: OptionsListAdapter,
-        saveButton: TextView
+        questionUi: QuestionUi.QuestionCreator, saveButton: TextView
     ) {
         // Validation criteria
         // No empty answers.
         // At least one answer.
-        val isPoll = isPoll()
-//        val isMultiOptionCreation = isMultiOptionQuestionCreation(questionTypeSpinner)
-        val allOptionsFilledInWithNoBlanks =  (optionsAdapter.currentList.none { it.text.isBlank() } &&
-            optionsAdapter.currentList.size > 0)
-
-        val enableButton = if(isPoll) {
-            allOptionsFilledInWithNoBlanks
-        } else {
-            // it's a quiz
-            // we have to check if every single choice and multi choice has
-            //  at least one answer selected
-            allOptionsFilledInWithNoBlanks &&
-                    optionsAdapter.currentList.any { it.isChecked }
-        }
-
-        if(enableButton)
-            saveButton.saveButtonEnabled()
-        else
-            saveButton.saveButtonDisabled()
+        val isPoll = isPoll
+        if (questionUi.currentQuestion.isValid(isPoll)) saveButton.saveButtonEnabled()
+        else saveButton.saveButtonDisabled()
     }
 
     private fun bind(questionUi: QuestionUi.MultiChoiceQuestion) {
-        with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding){
+
+        with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding) {
             questionTitle.text = questionUi.withTitle
-            val adapter = ArrayAdapter<String>(binding.root.context, android.R.layout.simple_list_item_1)
+            val adapter =
+                ArrayAdapter<String>(binding.root.context, android.R.layout.simple_list_item_1)
 //            options.layoutManager = LinearLayoutManager(binding.root.context)
             adapter.addAll(questionUi.options)
             options.adapter = adapter
@@ -225,9 +298,10 @@ class PollQuestionViewHolder<T : ViewBinding>(val binding: T,
     }
 
     private fun bind(questionUi: QuestionUi.SingleChoiceQuestion) {
-        with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding){
+        with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding) {
             questionTitle.text = questionUi.withTitle
-            val adapter = ArrayAdapter<String>(binding.root.context, android.R.layout.simple_list_item_1)
+            val adapter =
+                ArrayAdapter<String>(binding.root.context, android.R.layout.simple_list_item_1)
 //            options.layoutManager = LinearLayoutManager(binding.root.context)
             adapter.addAll(questionUi.options)
             options.adapter = adapter
@@ -240,10 +314,12 @@ class PollQuestionViewHolder<T : ViewBinding>(val binding: T,
             questionHeading.text = questionUi.text
         }
     }
+
     private fun bind(questionUi: QuestionUi.LongAnswer) {
         with(binding as LayoutPollQuizItemShortAnswerBinding) {
             questionNumberHeading.text = "QUESTION ${questionUi.index} : Long Answer"
             questionHeading.text = questionUi.text
         }
     }
+
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -24,7 +24,7 @@ import live.hms.roomkit.util.setOnSingleClickListener
 private var count : Long = 0
 sealed class QuestionUi(open val index : Long, open val viewType : Int, open val requiredToAnswer : Boolean){
     // Makes the creator UI show up first.
-    object QuestionCreator : QuestionUi(0, 0, false)
+    data class QuestionCreator(var questionUi: QuestionUi? = null) : QuestionUi(0, 0, false)
 
     // Actual questions that might be asked.
     data class MultiChoiceQuestion(val withTitle: String, val options: List<String>, val correctOptionIndex: List<Int>?, override val index : Long,
@@ -51,7 +51,7 @@ class PollQuestionViewHolder<T : ViewBinding>(val binding: T,
 
     fun bind(questionUi: QuestionUi) {
         when(questionUi) {
-            is QuestionUi.QuestionCreator -> bind(QuestionUi.QuestionCreator)
+            is QuestionUi.QuestionCreator -> bind(QuestionUi.QuestionCreator())
             is QuestionUi.LongAnswer -> bind(questionUi)
             is QuestionUi.MultiChoiceQuestion -> bind(questionUi)
             is QuestionUi.ShortAnswer -> bind(questionUi)

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -160,6 +160,11 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 setDrawable(binding.root.context.getDrawable(R.drawable.polls_creation_divider)!!)
             }
             var skipSelection = true
+            // Remove all item decorators
+            while (optionsListView.getItemDecorationCount() > 0) {
+                optionsListView.removeItemDecorationAt(0);
+            }
+            // Add it back if it's polls.
             if (isPoll) optionsListView.addItemDecoration(divider)
             setCurrentSelection(questionTypeSpinner, questionUi)
             skipSelection = false

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -41,8 +41,8 @@ class PollQuestionViewHolder<T : ViewBinding>(
     fun bind(questionUi: QuestionUi) {
         when (questionUi) {
             is QuestionUi.QuestionCreator -> bind(questionUi)
-            is QuestionUi.LongAnswer -> bind(questionUi)
-            is QuestionUi.ShortAnswer -> bind(questionUi)
+//            is QuestionUi.LongAnswer -> bind(questionUi)
+//            is QuestionUi.ShortAnswer -> bind(questionUi)
             is QuestionUi.AddAnotherItemView -> bind(questionUi)
             is QuestionUi.LaunchButton -> bind(questionUi)
             is QuestionUi.ChoiceQuestions -> bind(questionUi)
@@ -283,18 +283,18 @@ class PollQuestionViewHolder<T : ViewBinding>(
 //        }
 //    }
 
-    private fun bind(questionUi: QuestionUi.ShortAnswer) {
-        with(binding as LayoutPollQuizItemShortAnswerBinding) {
-            questionNumberHeading.text = "QUESTION ${questionUi.index} : Short Answer"
-            questionHeading.text = questionUi.text
-        }
-    }
-
-    private fun bind(questionUi: QuestionUi.LongAnswer) {
-        with(binding as LayoutPollQuizItemShortAnswerBinding) {
-            questionNumberHeading.text = "QUESTION ${questionUi.index} : Long Answer"
-            questionHeading.text = questionUi.text
-        }
-    }
+//    private fun bind(questionUi: QuestionUi.ShortAnswer) {
+//        with(binding as LayoutPollQuizItemShortAnswerBinding) {
+//            questionNumberHeading.text = "QUESTION ${questionUi.index} : Short Answer"
+//            questionHeading.text = questionUi.text
+//        }
+//    }
+//
+//    private fun bind(questionUi: QuestionUi.LongAnswer) {
+//        with(binding as LayoutPollQuizItemShortAnswerBinding) {
+//            questionNumberHeading.text = "QUESTION ${questionUi.index} : Long Answer"
+//            questionHeading.text = questionUi.text
+//        }
+//    }
 
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -22,6 +22,7 @@ import live.hms.roomkit.databinding.LayoutLaunchPollButtonBinding
 import live.hms.roomkit.databinding.LayoutPollQuestionCreationItemBinding
 import live.hms.roomkit.databinding.LayoutPollQuizItemShortAnswerBinding
 import live.hms.roomkit.databinding.LayoutPollQuizOptionsItemMultiChoiceBinding
+import live.hms.roomkit.setOnSingleClickListener
 import live.hms.roomkit.ui.theme.applyTheme
 import live.hms.roomkit.ui.theme.saveButtonDisabled
 import live.hms.roomkit.ui.theme.saveButtonEnabled
@@ -34,7 +35,9 @@ class PollQuestionViewHolder<T : ViewBinding>(
     val reAddQuestionCreator: () -> Unit,
     val getItem: (position: Int) -> QuestionUi.QuestionCreator,
     val launchPoll : () -> Unit,
-    val refresh : (position : Int) -> Unit
+    val refresh : (position : Int) -> Unit,
+    val editQuestion : (position : Int) -> Unit,
+    val deleteQuestion : (position : Int) -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
     private val TAG = "PollQuestionViewHolder"
 
@@ -258,6 +261,12 @@ class PollQuestionViewHolder<T : ViewBinding>(
     private fun bind(questionUi: QuestionUi.ChoiceQuestions) {
         with(binding as LayoutPollQuizOptionsItemMultiChoiceBinding) {
             applyTheme()
+            editQuestionButton.setOnClickListener {
+                editQuestion(bindingAdapterPosition)
+            }
+            deleteOptionTrashButton.setOnClickListener {
+                deleteQuestion(bindingAdapterPosition)
+            }
             questionTitle.text = questionUi.withTitle
             questionNumbering.text = "QUESTION ${questionUi.index} of something: ${if(questionUi is QuestionUi.SingleChoiceQuestion) "SINGLE CHOICE" else "MULTIPLE CHOICE"}"
             val adapter = GroupieAdapter()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollsCreationFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollsCreationFragment.kt
@@ -53,11 +53,13 @@ class PollsCreationFragment : Fragment(){
             pollButton.setOnSingleClickListener {
                 highlightPollOrQuiz(true)
                 toggleStartButtonText(true)
+                changePollQuizTitleHint(true)
                 pollsViewModel.setPollOrQuiz(true)
             }
             pollButton.callOnClick()
             quizButton.setOnSingleClickListener {
                 highlightPollOrQuiz(false)
+                changePollQuizTitleHint(false)
                 toggleStartButtonText(false)
                 pollsViewModel.setPollOrQuiz(false)
             }
@@ -101,6 +103,9 @@ class PollsCreationFragment : Fragment(){
 
     private fun toggleStartButtonText(isPoll: Boolean) {
         binding.startPollButton.text = if(isPoll) getText(R.string.hms_start_poll) else getText(R.string.hms_start_quiz)
+    }
+    private fun changePollQuizTitleHint(isPoll : Boolean) {
+        binding.pollTitleEditText.hint = if(isPoll) getText(R.string.hms_name_this_poll) else getText(R.string.hms_name_this_quiz)
     }
     private fun highlightPollOrQuiz(isPoll : Boolean) {
         // Whichever button is selected, disable it.

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollsCreationFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollsCreationFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import kotlinx.coroutines.launch
+import live.hms.roomkit.R
 import live.hms.roomkit.databinding.LayoutPollsCreationBinding
 import live.hms.roomkit.ui.meeting.MeetingViewModel
 import live.hms.roomkit.ui.polls.previous.PreviousPollsAdaptor
@@ -51,11 +52,13 @@ class PollsCreationFragment : Fragment(){
             hideVoteCount.setOnCheckedChangeListener { _, isChecked -> pollsViewModel.markHideVoteCount(isChecked) }
             pollButton.setOnSingleClickListener {
                 highlightPollOrQuiz(true)
+                toggleStartButtonText(true)
                 pollsViewModel.setPollOrQuiz(true)
             }
             pollButton.callOnClick()
             quizButton.setOnSingleClickListener {
                 highlightPollOrQuiz(false)
+                toggleStartButtonText(false)
                 pollsViewModel.setPollOrQuiz(false)
             }
             anonymous.setOnCheckedChangeListener { _, isChecked -> pollsViewModel.isAnon(isChecked) }
@@ -96,6 +99,9 @@ class PollsCreationFragment : Fragment(){
         findNavController().navigate(PollsCreationFragmentDirections.actionPollsCreationFragmentToPollQuestionCreation(pollsViewModel.isPoll()))
     }
 
+    private fun toggleStartButtonText(isPoll: Boolean) {
+        binding.startPollButton.text = if(isPoll) getText(R.string.hms_start_poll) else getText(R.string.hms_start_quiz)
+    }
     private fun highlightPollOrQuiz(isPoll : Boolean) {
         // Whichever button is selected, disable it.
         // Hopefully the UI for the opposite one will be grayed.

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollsCreationFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollsCreationFragment.kt
@@ -44,7 +44,7 @@ class PollsCreationFragment : Fragment(){
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initOnBackPress()
-        binding.creationFlowUi.visibility = View.GONE//if (meetingViewModel.isAllowedToCreatePolls()) View.VISIBLE else View.GONE
+        binding.creationFlowUi.visibility = if (meetingViewModel.isAllowedToCreatePolls()) View.VISIBLE else View.GONE
         with(binding) {
             applyTheme()
             backButton.setOnSingleClickListener { findNavController().popBackStack() }
@@ -93,7 +93,7 @@ class PollsCreationFragment : Fragment(){
         // Move to the next fragment but the data is only carried forward isn't it?
         //  It's not quite used yet.
         // Perhaps it really should be a common VM for all these fragments.
-        findNavController().navigate(PollsCreationFragmentDirections.actionPollsCreationFragmentToPollQuestionCreation())
+        findNavController().navigate(PollsCreationFragmentDirections.actionPollsCreationFragmentToPollQuestionCreation(pollsViewModel.isPoll()))
     }
 
     private fun highlightPollOrQuiz(isPoll : Boolean) {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionToOptions.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionToOptions.kt
@@ -1,0 +1,22 @@
+package live.hms.roomkit.ui.polls
+
+class QuestionToOptions {
+    fun questionToOptions(question: QuestionUi.SingleChoiceQuestion, isPoll : Boolean): List<Option>  {
+        val selectedOptionIndex = question.selections.firstOrNull()
+        return question.options.mapIndexed { int, text ->
+            Option(text, false, int == selectedOptionIndex)
+        }
+    }
+    fun questionToOptions(question: QuestionUi.MultiChoiceQuestion, isPoll : Boolean): List<Option>  {
+        val selectedOptionIndex = question.selections
+        return question.options.mapIndexed { int, text ->
+            Option(text, false, int in selectedOptionIndex)
+        }
+    }
+    fun questionToOptions(question: QuestionUi.ChoiceQuestions?, isPoll : Boolean) : List<Option>? =
+        when (question?.viewType) {
+            1 -> questionToOptions(question as QuestionUi.MultiChoiceQuestion, isPoll)
+            2 -> questionToOptions(question as QuestionUi.SingleChoiceQuestion, isPoll)
+            else -> null
+        }
+}

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionToOptions.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionToOptions.kt
@@ -1,16 +1,16 @@
 package live.hms.roomkit.ui.polls
 
 class QuestionToOptions {
-    fun questionToOptions(question: QuestionUi.SingleChoiceQuestion, isPoll : Boolean): List<Option>  {
+    private fun questionToOptions(question: QuestionUi.SingleChoiceQuestion, isPoll : Boolean): List<Option>  {
         val selectedOptionIndex = question.selections.firstOrNull()
         return question.options.mapIndexed { int, text ->
-            Option(text, false, int == selectedOptionIndex)
+            Option(text, if(isPoll) null else false, int == selectedOptionIndex)
         }
     }
-    fun questionToOptions(question: QuestionUi.MultiChoiceQuestion, isPoll : Boolean): List<Option>  {
+    private fun questionToOptions(question: QuestionUi.MultiChoiceQuestion, isPoll : Boolean): List<Option>  {
         val selectedOptionIndex = question.selections
         return question.options.mapIndexed { int, text ->
-            Option(text, false, int in selectedOptionIndex)
+            Option(text, if(isPoll) null else true, int in selectedOptionIndex)
         }
     }
     fun questionToOptions(question: QuestionUi.ChoiceQuestions?, isPoll : Boolean) : List<Option>? =

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -4,11 +4,14 @@ sealed class QuestionUi(
     open var index: Long,
     open val viewType: Int
 ) {
+    abstract fun getItemId() : Long
     // Makes the creator UI show up first.
     data class QuestionCreator(var currentQuestion: ChoiceQuestions = SingleChoiceQuestion(),
                                var isPoll : Boolean = true,
                                var requiredToAnswer: Boolean = false,
-    ) : QuestionUi(0, 0)
+    ) : QuestionUi(0, 0) {
+        override fun getItemId(): Long = viewType.toLong()
+    }
 
     sealed class ChoiceQuestions(
         override var index: Long,
@@ -23,6 +26,8 @@ sealed class QuestionUi(
                     options.isNotEmpty() &&
                     options.none { it.isEmpty()}
         }
+
+        override fun getItemId(): Long = 1000 + index
     }
 
     // Actual questions that might be asked.
@@ -52,12 +57,20 @@ sealed class QuestionUi(
 
     data class LongAnswer(
         val text: String, override var index: Long,
-    ) : QuestionUi(index, 3)
+    ) : QuestionUi(index, 3){
+        override fun getItemId(): Long = TODO()
+    }
 
     data class ShortAnswer(
         val text: String, override var index: Long,
-    ) : QuestionUi(index, 4)
+    ) : QuestionUi(index, 4) {
+        override fun getItemId(): Long = TODO()
+    }
 
-    object AddAnotherItemView : QuestionUi(-1, 5)
-    object LaunchButton : QuestionUi(-2, 6)
+    object AddAnotherItemView : QuestionUi(-1, 5){
+        override fun getItemId(): Long = viewType.toLong()
+    }
+    data class LaunchButton(val isPoll : Boolean, var enabled : Boolean) : QuestionUi(-2, 6){
+        override fun getItemId(): Long = viewType.toLong()
+    }
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -1,0 +1,63 @@
+package live.hms.roomkit.ui.polls
+
+sealed class QuestionUi(
+    open var index: Long,
+    open val viewType: Int,
+    open var requiredToAnswer: Boolean
+) {
+    // Makes the creator UI show up first.
+    data class QuestionCreator(var currentQuestion: ChoiceQuestions = SingleChoiceQuestion(),
+                               var isPoll : Boolean = true
+    ) : QuestionUi(0, 0, false)
+
+    sealed class ChoiceQuestions(
+        override var index: Long,
+        override val viewType: Int,
+        override var requiredToAnswer: Boolean,
+        open var withTitle: String = "",
+        open var options: List<String> = emptyList(),
+        open var selections : List<Int> = emptyList()
+    ) : QuestionUi(index, viewType, requiredToAnswer){
+        open fun isValid(isPoll : Boolean) : Boolean {
+            return withTitle.isNotEmpty() &&
+                    options.isNotEmpty() &&
+                    options.none { it.isEmpty()}
+        }
+    }
+
+    // Actual questions that might be asked.
+    data class MultiChoiceQuestion(
+        override var withTitle: String = "",
+        override var options: List<String> = listOf("",""),
+        var correctOptionIndex: List<Int>? = null,
+        override var index: Long = -1,
+        override var requiredToAnswer: Boolean = false
+    ) : ChoiceQuestions(index, 1, requiredToAnswer) {
+        override fun isValid(isPoll : Boolean): Boolean {
+            return super.isValid(isPoll) && (isPoll || correctOptionIndex != null)
+        }
+    }
+
+    data class SingleChoiceQuestion(
+        override var withTitle: String = "",
+        override var options: List<String> = listOf("",""),
+        var correctOptionIndex: Int? = null,
+        override var index: Long = -1,
+        override var requiredToAnswer: Boolean = false
+    ) : ChoiceQuestions(index, 2, requiredToAnswer) {
+        override fun isValid(isPoll : Boolean): Boolean {
+            return super.isValid(isPoll) && (isPoll || correctOptionIndex != null)
+        }
+    }
+
+    data class LongAnswer(
+        val text: String, override var index: Long, override var requiredToAnswer: Boolean
+    ) : QuestionUi(index, 3, requiredToAnswer)
+
+    data class ShortAnswer(
+        val text: String, override var index: Long, override var requiredToAnswer: Boolean
+    ) : QuestionUi(index, 4, requiredToAnswer)
+
+    object AddAnotherItemView : QuestionUi(-1, 5, false)
+    object LaunchButton
+}

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -9,6 +9,7 @@ sealed class QuestionUi(
     data class QuestionCreator(var currentQuestion: ChoiceQuestions = SingleChoiceQuestion(),
                                var isPoll : Boolean = true,
                                var requiredToAnswer: Boolean = false,
+        val questionInEditIndex : Long? = null
     ) : QuestionUi(0, 0) {
         override fun getItemId(): Long = viewType.toLong() // It's always first and there's only one
     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -39,7 +39,7 @@ sealed class QuestionUi(
         override var requiredToAnswer: Boolean = false
     ) : ChoiceQuestions(index, 1, requiredToAnswer) {
         override fun isValid(isPoll : Boolean): Boolean {
-            return super.isValid(isPoll) && (isPoll || correctOptionIndex != null)
+            return super.isValid(isPoll) && (isPoll || selections.isNotEmpty())
         }
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -10,7 +10,7 @@ sealed class QuestionUi(
                                var isPoll : Boolean = true,
                                var requiredToAnswer: Boolean = false,
     ) : QuestionUi(0, 0) {
-        override fun getItemId(): Long = viewType.toLong()
+        override fun getItemId(): Long = viewType.toLong() // It's always first and there's only one
     }
 
     sealed class ChoiceQuestions(
@@ -68,9 +68,9 @@ sealed class QuestionUi(
     }
 
     object AddAnotherItemView : QuestionUi(-1, 5){
-        override fun getItemId(): Long = viewType.toLong()
+        override fun getItemId(): Long = viewType.toLong() + 2000
     }
     data class LaunchButton(val isPoll : Boolean, var enabled : Boolean) : QuestionUi(-2, 6){
-        override fun getItemId(): Long = viewType.toLong()
+        override fun getItemId(): Long = viewType.toLong() + 2000
     }
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -51,7 +51,7 @@ sealed class QuestionUi(
         override var requiredToAnswer: Boolean = false
     ) : ChoiceQuestions(index, 2, requiredToAnswer) {
         override fun isValid(isPoll : Boolean): Boolean {
-            return super.isValid(isPoll) && (isPoll || correctOptionIndex != null)
+            return super.isValid(isPoll) && (isPoll || selections.isNotEmpty())
         }
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -2,22 +2,22 @@ package live.hms.roomkit.ui.polls
 
 sealed class QuestionUi(
     open var index: Long,
-    open val viewType: Int,
-    open var requiredToAnswer: Boolean
+    open val viewType: Int
 ) {
     // Makes the creator UI show up first.
     data class QuestionCreator(var currentQuestion: ChoiceQuestions = SingleChoiceQuestion(),
-                               var isPoll : Boolean = true
-    ) : QuestionUi(0, 0, false)
+                               var isPoll : Boolean = true,
+                               var requiredToAnswer: Boolean = false,
+    ) : QuestionUi(0, 0)
 
     sealed class ChoiceQuestions(
         override var index: Long,
         override val viewType: Int,
-        override var requiredToAnswer: Boolean,
+        open var requiredToAnswer: Boolean,
         open var withTitle: String = "",
         open var options: List<String> = emptyList(),
-        open var selections : List<Int> = emptyList()
-    ) : QuestionUi(index, viewType, requiredToAnswer){
+        open var selections : List<Int> = emptyList(),
+    ) : QuestionUi(index, viewType){
         open fun isValid(isPoll : Boolean) : Boolean {
             return withTitle.isNotEmpty() &&
                     options.isNotEmpty() &&
@@ -51,13 +51,13 @@ sealed class QuestionUi(
     }
 
     data class LongAnswer(
-        val text: String, override var index: Long, override var requiredToAnswer: Boolean
-    ) : QuestionUi(index, 3, requiredToAnswer)
+        val text: String, override var index: Long,
+    ) : QuestionUi(index, 3)
 
     data class ShortAnswer(
-        val text: String, override var index: Long, override var requiredToAnswer: Boolean
-    ) : QuestionUi(index, 4, requiredToAnswer)
+        val text: String, override var index: Long,
+    ) : QuestionUi(index, 4)
 
-    object AddAnotherItemView : QuestionUi(-1, 5, false)
-    object LaunchButton
+    object AddAnotherItemView : QuestionUi(-1, 5)
+    object LaunchButton : QuestionUi(-2, 6)
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -21,6 +21,7 @@ sealed class QuestionUi(
         open var withTitle: String = "",
         open var options: List<String> = emptyList(),
         open var selections : List<Int> = emptyList(),
+        open var totalQuestions : Long
     ) : QuestionUi(index, viewType){
         open fun isValid(isPoll : Boolean) : Boolean {
             return withTitle.isNotEmpty() &&
@@ -37,8 +38,9 @@ sealed class QuestionUi(
         override var options: List<String> = listOf("",""),
         var correctOptionIndex: List<Int>? = null,
         override var index: Long = -1,
-        override var requiredToAnswer: Boolean = false
-    ) : ChoiceQuestions(index, 1, requiredToAnswer) {
+        override var requiredToAnswer: Boolean = false,
+        override var totalQuestions: Long = 0
+    ) : ChoiceQuestions(index, 1, requiredToAnswer, totalQuestions = totalQuestions) {
         override fun isValid(isPoll : Boolean): Boolean {
             return super.isValid(isPoll) && (isPoll || selections.isNotEmpty())
         }
@@ -49,8 +51,9 @@ sealed class QuestionUi(
         override var options: List<String> = listOf("",""),
         var correctOptionIndex: Int? = null,
         override var index: Long = -1,
-        override var requiredToAnswer: Boolean = false
-    ) : ChoiceQuestions(index, 2, requiredToAnswer) {
+        override var requiredToAnswer: Boolean = false,
+        override var totalQuestions: Long = 0
+    ) : ChoiceQuestions(index, 2, requiredToAnswer, totalQuestions = totalQuestions) {
         override fun isValid(isPoll : Boolean): Boolean {
             return super.isValid(isPoll) && (isPoll || selections.isNotEmpty())
         }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -39,8 +39,9 @@ sealed class QuestionUi(
         var correctOptionIndex: List<Int>? = null,
         override var index: Long = -1,
         override var requiredToAnswer: Boolean = false,
-        override var totalQuestions: Long = 0
-    ) : ChoiceQuestions(index, 1, requiredToAnswer, totalQuestions = totalQuestions) {
+        override var totalQuestions: Long = 0,
+        override var selections: List<Int> = emptyList()
+    ) : ChoiceQuestions(index, 1, requiredToAnswer, totalQuestions = totalQuestions, selections = selections) {
         override fun isValid(isPoll : Boolean): Boolean {
             return super.isValid(isPoll) && (isPoll || selections.isNotEmpty())
         }
@@ -52,8 +53,9 @@ sealed class QuestionUi(
         var correctOptionIndex: Int? = null,
         override var index: Long = -1,
         override var requiredToAnswer: Boolean = false,
-        override var totalQuestions: Long = 0
-    ) : ChoiceQuestions(index, 2, requiredToAnswer, totalQuestions = totalQuestions) {
+        override var totalQuestions: Long = 0,
+        override var selections : List<Int> = emptyList()
+    ) : ChoiceQuestions(index, 2, requiredToAnswer, totalQuestions = totalQuestions, selections = selections) {
         override fun isValid(isPoll : Boolean): Boolean {
             return super.isValid(isPoll) && (isPoll || selections.isNotEmpty())
         }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/QuestionUi.kt
@@ -55,17 +55,17 @@ sealed class QuestionUi(
         }
     }
 
-    data class LongAnswer(
-        val text: String, override var index: Long,
-    ) : QuestionUi(index, 3){
-        override fun getItemId(): Long = TODO()
-    }
-
-    data class ShortAnswer(
-        val text: String, override var index: Long,
-    ) : QuestionUi(index, 4) {
-        override fun getItemId(): Long = TODO()
-    }
+//    data class LongAnswer(
+//        val text: String, override var index: Long,
+//    ) : QuestionUi(index, 3){
+//        override fun getItemId(): Long = TODO()
+//    }
+//
+//    data class ShortAnswer(
+//        val text: String, override var index: Long,
+//    ) : QuestionUi(index, 4) {
+//        override fun getItemId(): Long = TODO()
+//    }
 
     object AddAnotherItemView : QuestionUi(-1, 5){
         override fun getItemId(): Long = viewType.toLong() + 2000

--- a/room-kit/src/main/java/live/hms/roomkit/ui/theme/ThemeExt.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/theme/ThemeExt.kt
@@ -2203,13 +2203,6 @@ fun LayoutPollQuestionCreationItemBinding.applyTheme() {
 
     setSwitchThemes(notRequiredToAnswer)
 
-    deleteOptionTrashButton.drawable.setTint(
-        getColorOrDefault(
-            HMSPrebuiltTheme.getColours()?.onSurfaceHigh,
-            HMSPrebuiltTheme.getDefaults().onsurface_high_emp
-        )
-    )
-
     saveButton.saveButtonEnabled()
 
 
@@ -2285,7 +2278,12 @@ fun LayoutPollQuizOptionsItemBinding.setTheme() {
 
     radioButton.buttonTintList = trackTintList()
     checkbox.buttonTintList = trackTintList()
-
+    deleteOptionTrashButton.drawable.setTint(
+        getColorOrDefault(
+            HMSPrebuiltTheme.getColours()?.onSurfaceHigh,
+            HMSPrebuiltTheme.getDefaults().onsurface_high_emp
+        )
+    )
 }
 
 fun TextView.pollsStatusLiveDraftEnded(state: HmsPollState) {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/theme/ThemeExt.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/theme/ThemeExt.kt
@@ -2258,6 +2258,11 @@ internal fun TextView.saveButtonDisabled() {
 
 
 fun LayoutPollQuizOptionsItemMultiChoiceBinding.applyTheme() {
+    backingCard.setCardBackgroundColor(getColorOrDefault(
+        HMSPrebuiltTheme.getColours()?.surfaceDefault,
+        HMSPrebuiltTheme.getDefaults().surface_default)
+    )
+
     deleteOptionTrashButton.drawable.setTint(
         getColorOrDefault(
             HMSPrebuiltTheme.getColours()?.onSurfaceHigh,

--- a/room-kit/src/main/java/live/hms/roomkit/ui/theme/ThemeExt.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/theme/ThemeExt.kt
@@ -2254,6 +2254,22 @@ internal fun TextView.saveButtonDisabled() {
 
 }
 
+
+fun LayoutPollQuizOptionsItemMultiChoiceBinding.applyTheme() {
+    questionNumbering.setTextColor(
+        getColorOrDefault(
+            HMSPrebuiltTheme.getColours()?.onSurfaceLow,
+            HMSPrebuiltTheme.getDefaults().onsurface_low_emp
+        )
+    )
+    questionTitle.setTextColor(
+        getColorOrDefault(
+            HMSPrebuiltTheme.getColours()?.onSurfaceHigh,
+            HMSPrebuiltTheme.getDefaults().onsurface_high_emp
+        )
+    )
+}
+
 fun LayoutPollQuizOptionsItemBinding.setTheme() {
 
     text.setBackgroundAndColor(
@@ -2403,4 +2419,13 @@ fun MaterialCardView.highlightCorrectAnswer(isCorrect : Boolean) {
         )
     }
     strokeWidth = 1.dp()
+}
+
+internal fun LayoutMultiChoiceQuestionOptionItemBinding.applyTheme() {
+    optionText.setTextColor(
+        getColorOrDefault(
+            HMSPrebuiltTheme.getColours()?.onSurfaceMedium,
+            HMSPrebuiltTheme.getDefaults().onsurface_med_emp
+        )
+    )
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/theme/ThemeExt.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/theme/ThemeExt.kt
@@ -2256,6 +2256,13 @@ internal fun TextView.saveButtonDisabled() {
 
 
 fun LayoutPollQuizOptionsItemMultiChoiceBinding.applyTheme() {
+    deleteOptionTrashButton.drawable.setTint(
+        getColorOrDefault(
+            HMSPrebuiltTheme.getColours()?.onSurfaceHigh,
+            HMSPrebuiltTheme.getDefaults().onsurface_high_emp
+        )
+    )
+    editQuestionButton.saveButtonEnabled()
     questionNumbering.setTextColor(
         getColorOrDefault(
             HMSPrebuiltTheme.getColours()?.onSurfaceLow,

--- a/room-kit/src/main/java/live/hms/roomkit/util/ViewExt.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/util/ViewExt.kt
@@ -42,9 +42,6 @@ fun View.setOnSingleClickListener(l: View.OnClickListener) {
 private fun getDip(): Float = Resources.getSystem().displayMetrics.density
 fun Float.dp() = this * getDip()
 fun Int.dp() = (this * getDip()).roundToInt()
-fun View.setOnSingleClickListener(l: (View) -> Unit) {
-  setOnClickListener(OnSingleClickListener(l))
-}
 
 // Keep the listener at last such that we can use kotlin lambda
 fun View.setOnSingleClickListener(waitDelay: Long, l: View.OnClickListener) {

--- a/room-kit/src/main/res/drawable/divider_poll_question_creation.xml
+++ b/room-kit/src/main/res/drawable/divider_poll_question_creation.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="345dp"
+    android:height="1dp"
+    android:viewportWidth="345"
+    android:viewportHeight="1">
+  <path
+      android:pathData="M0,1l345,-0l0,-1l-345,-0z"
+      android:fillColor="#1D1F27"/>
+</vector>

--- a/room-kit/src/main/res/layout/layout_add_more.xml
+++ b/room-kit/src/main/res/layout/layout_add_more.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
     <TextView
         android:id="@+id/addMoreOptions"
         android:layout_width="match_parent"

--- a/room-kit/src/main/res/layout/layout_add_more.xml
+++ b/room-kit/src/main/res/layout/layout_add_more.xml
@@ -9,7 +9,7 @@
         android:drawablePadding="8dp"
         android:drawableStart="@drawable/add_ic"
         android:padding="@dimen/eight_dp"
-        android:text="Add an option"
+        android:text="Add another question"
         android:gravity="center_vertical"
         android:textSize="14sp"
         android:fontFamily="@font/inter_regular"

--- a/room-kit/src/main/res/layout/layout_launch_poll_button.xml
+++ b/room-kit/src/main/res/layout/layout_launch_poll_button.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="right">
+    <TextView
+        android:id="@+id/launchPollQuiz"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="@dimen/spacing_d3"
+        android:gravity="center"
+        android:paddingHorizontal="@dimen/spacing_d2"
+        android:paddingVertical="@dimen/spacing_d1"
+        tools:text="Launch Poll"
+        android:lineHeight="24px"
+        android:textSize="16sp"
+        android:fontFamily="@font/inter_semibold" />
+</LinearLayout>

--- a/room-kit/src/main/res/layout/layout_launch_poll_button.xml
+++ b/room-kit/src/main/res/layout/layout_launch_poll_button.xml
@@ -8,7 +8,6 @@
         android:id="@+id/launchPollQuiz"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginRight="@dimen/spacing_d3"
         android:gravity="center"
         android:paddingHorizontal="@dimen/spacing_d2"
         android:paddingVertical="@dimen/spacing_d1"

--- a/room-kit/src/main/res/layout/layout_launch_poll_button.xml
+++ b/room-kit/src/main/res/layout/layout_launch_poll_button.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_gravity="right">
+    android:gravity="end">
     <TextView
         android:id="@+id/launchPollQuiz"
         android:layout_width="wrap_content"

--- a/room-kit/src/main/res/layout/layout_multi_choice_question_option_item.xml
+++ b/room-kit/src/main/res/layout/layout_multi_choice_question_option_item.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/optionText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/inter_regular"
+        android:lineHeight="20dp"
+        android:textSize="14sp" />
+</LinearLayout>

--- a/room-kit/src/main/res/layout/layout_multi_choice_question_option_item.xml
+++ b/room-kit/src/main/res/layout/layout_multi_choice_question_option_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <TextView
         android:id="@+id/optionText"

--- a/room-kit/src/main/res/layout/layout_poll_question_creation.xml
+++ b/room-kit/src/main/res/layout/layout_poll_question_creation.xml
@@ -55,6 +55,7 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/createdQuestionList"
             android:layout_width="match_parent"
+            android:focusableInTouchMode="true"
             android:layout_height="match_parent"
             android:layout_marginLeft="24dp"
             android:layout_marginRight="24dp"

--- a/room-kit/src/main/res/layout/layout_poll_question_creation.xml
+++ b/room-kit/src/main/res/layout/layout_poll_question_creation.xml
@@ -45,7 +45,7 @@
             android:gravity="center"
             android:paddingHorizontal="16dp"
             android:paddingVertical="8dp"
-            android:text="Launch Quiz"
+            android:text="Add Questions"
             android:textColor="#EFF0FA"
             android:textSize="14sp"
             android:textStyle="bold"

--- a/room-kit/src/main/res/layout/layout_poll_question_creation.xml
+++ b/room-kit/src/main/res/layout/layout_poll_question_creation.xml
@@ -1,73 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:scrollbars="none"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root"
-    android:layout_height="wrap_content">
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:windowSoftInputMode="adjustPan">
+
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:windowSoftInputMode="adjustPan">
+        android:layout_marginTop="@dimen/spacing_d3"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        >
+    <ImageView
+        android:id="@+id/backButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/spacing_d3"
+        android:src="@drawable/left_arrow"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
+    <TextView
+        android:id="@+id/heading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:fontFamily="@font/inter_semibold"
+        tools:text="Poll/Quiz"
+        android:lineHeight="24px"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="@id/backButton"
+        app:layout_constraintLeft_toRightOf="@id/backButton"
+        app:layout_constraintTop_toTopOf="@id/backButton" />
 
-        <ImageView
-            android:id="@+id/backButton"
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:layout_marginLeft="@dimen/spacing_d3"
-            android:layout_marginTop="@dimen/spacing_d3"
-            android:src="@drawable/left_arrow"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    </LinearLayout>
 
-        <TextView
-            android:id="@+id/heading"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
-            android:fontFamily="@font/inter_semibold"
-            android:text="Poll/Quiz"
-            android:textSize="20sp"
-            app:layout_constraintBottom_toBottomOf="@id/backButton"
-            app:layout_constraintLeft_toRightOf="@id/backButton"
-            app:layout_constraintTop_toTopOf="@id/backButton" />
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/spacing_d2"
+        android:src="@drawable/divider_poll_question_creation"
+        />
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/createdQuestionList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginLeft="24dp"
+        android:layout_marginRight="24dp"
+        android:focusableInTouchMode="true"
+        tools:itemCount="2"
+        tools:listitem="@layout/layout_poll_question_creation_item" />
 
-        <TextView
-            android:id="@+id/launchPollQuiz"
-            android:layout_width="wrap_content"
-            android:layout_height="48dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="@dimen/spacing_d3"
-
-            android:gravity="center"
-            android:paddingHorizontal="16dp"
-            android:paddingVertical="8dp"
-            android:text="Add Questions"
-            android:textColor="#EFF0FA"
-            android:textSize="14sp"
-            android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintRight_toRightOf="parent" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/createdQuestionList"
-            android:layout_width="match_parent"
-            android:focusableInTouchMode="true"
-            android:layout_height="match_parent"
-            android:layout_marginLeft="24dp"
-            android:layout_marginRight="24dp"
-            android:clipToPadding="false"
-            android:nestedScrollingEnabled="false"
-            android:paddingTop="42dp"
-            app:layout_constraintBottom_toTopOf="@id/launchPollQuiz"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/heading"
-            tools:itemCount="2"
-            tools:listitem="@layout/layout_poll_question_creation_item" />
-
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+</LinearLayout>

--- a/room-kit/src/main/res/layout/layout_poll_question_creation_item.xml
+++ b/room-kit/src/main/res/layout/layout_poll_question_creation_item.xml
@@ -108,6 +108,7 @@
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/optionsListView"
+                    android:focusableInTouchMode="true"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:nestedScrollingEnabled="false" />

--- a/room-kit/src/main/res/layout/layout_poll_question_creation_item.xml
+++ b/room-kit/src/main/res/layout/layout_poll_question_creation_item.xml
@@ -5,12 +5,7 @@
     android:layout_width="match_parent"
     android:id="@+id/root"
     android:windowSoftInputMode="adjustPan"
-    android:layout_height="match_parent">
-
-    <ScrollView
-        android:scrollbars="none"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent">
+    android:layout_height="wrap_content">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -183,6 +178,4 @@
             />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </ScrollView>
 </com.google.android.material.card.MaterialCardView>

--- a/room-kit/src/main/res/layout/layout_poll_question_creation_item.xml
+++ b/room-kit/src/main/res/layout/layout_poll_question_creation_item.xml
@@ -103,7 +103,6 @@
 
                 <androidx.recyclerview.widget.RecyclerView
                     android:id="@+id/optionsListView"
-                    android:focusableInTouchMode="true"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:nestedScrollingEnabled="false" />
@@ -149,17 +148,6 @@
             app:layout_constraintTop_toBottomOf="@id/notRequiredToAnswer"
             android:layout_marginVertical="@dimen/spacing_d1"
             android:background="@drawable/gray_line_vertical_divider" />
-
-
-        <ImageView
-            android:id="@+id/deleteOptionTrashButton"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:scaleType="center"
-            android:src="@drawable/delete_trash"
-            app:layout_constraintBottom_toBottomOf="@id/saveButton"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintTop_toTopOf="@id/saveButton" />
 
         <TextView
             android:id="@+id/saveButton"

--- a/room-kit/src/main/res/layout/layout_poll_quiz_options_item.xml
+++ b/room-kit/src/main/res/layout/layout_poll_quiz_options_item.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.LinearLayoutCompat
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:gravity="center_vertical">
     <RadioButton
         android:id="@+id/radioButton"
         android:layout_width="wrap_content"
@@ -14,12 +15,24 @@
         android:layout_height="wrap_content"
         />
     <EditText
+        android:layout_weight="1"
         android:hint="e.g. Who will win the match?"
         android:textSize="12sp"
         android:fontFamily="@font/inter_regular"
         android:id="@+id/text"
         android:paddingHorizontal="@dimen/spacing_d2"
         android:paddingVertical="12dp"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"/>
+
+    <ImageView
+        android:id="@+id/deleteOptionTrashButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:padding="8dp"
+        android:layout_gravity="center"
+        tools:tint="@color/black_overlay"
+        android:layout_marginLeft="@dimen/spacing_d1"
+        android:src="@drawable/delete_trash"
+         />
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/room-kit/src/main/res/layout/layout_poll_quiz_options_item_multi_choice.xml
+++ b/room-kit/src/main/res/layout/layout_poll_quiz_options_item_multi_choice.xml
@@ -2,18 +2,35 @@
 <androidx.appcompat.widget.LinearLayoutCompat
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <TextView
+        android:id="@+id/questionNumbering"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        tools:text="Question 1 of 2"
+        android:fontFamily="@font/inter_medium"
+        android:textSize="10sp"
+        android:lineHeight="16dp"
+        />
+
+    <TextView
         android:id="@+id/questionTitle"
+        android:fontFamily="@font/inter_regular"
+        android:textSize="16sp"
+        android:lineHeight="24dp"
         android:layout_width="match_parent"
+        android:layout_marginVertical="@dimen/spacing_d2"
         android:layout_height="wrap_content" />
 
-    <ListView
+    <androidx.recyclerview.widget.RecyclerView
+        android:nestedScrollingEnabled="false"
         android:id="@+id/options"
         android:layout_width="match_parent"
+        android:minHeight="60dp"
         android:layout_height="wrap_content" />
 
 </androidx.appcompat.widget.LinearLayoutCompat>

--- a/room-kit/src/main/res/layout/layout_poll_quiz_options_item_multi_choice.xml
+++ b/room-kit/src/main/res/layout/layout_poll_quiz_options_item_multi_choice.xml
@@ -1,36 +1,69 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.LinearLayoutCompat
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    app:strokeWidth="1dp">
 
-    <TextView
-        android:id="@+id/questionNumbering"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        tools:text="Question 1 of 2"
-        android:fontFamily="@font/inter_medium"
-        android:textSize="10sp"
-        android:lineHeight="16dp"
-        />
+        android:orientation="vertical"
+        android:layout_margin="@dimen/spacing_d2">
 
-    <TextView
-        android:id="@+id/questionTitle"
-        android:fontFamily="@font/inter_regular"
-        android:textSize="16sp"
-        android:lineHeight="24dp"
-        android:layout_width="match_parent"
-        android:layout_marginVertical="@dimen/spacing_d2"
-        android:layout_height="wrap_content" />
+        <TextView
+            android:id="@+id/questionNumbering"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/inter_medium"
+            android:lineHeight="16dp"
+            android:textSize="10sp"
+            tools:text="Question 1 of 2" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:nestedScrollingEnabled="false"
-        android:id="@+id/options"
-        android:layout_width="match_parent"
-        android:minHeight="60dp"
-        android:layout_height="wrap_content" />
+        <TextView
+            android:id="@+id/questionTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="@dimen/spacing_d2"
+            android:fontFamily="@font/inter_regular"
+            android:lineHeight="24dp"
+            android:textSize="16sp" />
 
-</androidx.appcompat.widget.LinearLayoutCompat>
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/options"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacing_d2"
+            android:nestedScrollingEnabled="false" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="end"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/deleteOptionTrashButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginRight="@dimen/spacing_d2"
+                android:src="@drawable/delete_trash"
+                tools:tint="@color/black_overlay" />
+
+            <TextView
+                android:id="@+id/editQuestionButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/inter_semibold"
+                android:gravity="center"
+                android:lineHeight="24px"
+                android:paddingHorizontal="@dimen/spacing_d2"
+                android:paddingVertical="@dimen/spacing_d1"
+                android:textSize="16sp"
+                android:text="Edit" />
+        </LinearLayout>
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/room-kit/src/main/res/layout/layout_poll_quiz_options_item_multi_choice.xml
+++ b/room-kit/src/main/res/layout/layout_poll_quiz_options_item_multi_choice.xml
@@ -4,8 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    app:strokeWidth="1dp">
+    app:cardCornerRadius="@dimen/spacing_d1"
+    android:id="@+id/backingCard"
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/room-kit/src/main/res/layout/layout_polls_creation.xml
+++ b/room-kit/src/main/res/layout/layout_polls_creation.xml
@@ -174,7 +174,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/eight_dp"
             android:layout_marginHorizontal="@dimen/spacing_d3"
-            android:hint="Name this poll"
+            tools:hint="Name this poll"
             app:layout_constraintLeft_toLeftOf="@id/poll_button"
             app:layout_constraintTop_toBottomOf="@id/quiz_name_str"
             />

--- a/room-kit/src/main/res/layout/layout_polls_creation.xml
+++ b/room-kit/src/main/res/layout/layout_polls_creation.xml
@@ -252,7 +252,7 @@
             android:textSize="14sp"
             android:textStyle="bold"
             android:fontFamily="@font/inter_bold"
-            android:text="Start Poll"
+            tools:text="Start Poll"
             app:layout_constraintTop_toBottomOf="@id/timer" />
 
         <TextView

--- a/room-kit/src/main/res/navigation/meeting_nav_graph.xml
+++ b/room-kit/src/main/res/navigation/meeting_nav_graph.xml
@@ -193,7 +193,11 @@
     <fragment
         android:id="@+id/pollQuestionCreation"
         android:name="live.hms.roomkit.ui.polls.PollQuestionCreation"
-        android:label="PollQuestionCreation" />
+        android:label="PollQuestionCreation" >
+        <argument
+            android:name="isPoll"
+            app:argType="boolean" />
+    </fragment>
     <fragment
         android:id="@+id/pollDisplayFragment"
         android:name="live.hms.roomkit.ui.polls.display.PollDisplayFragment"

--- a/room-kit/src/main/res/values/string_arrays.xml
+++ b/room-kit/src/main/res/values/string_arrays.xml
@@ -7,7 +7,5 @@
     <string-array name="question_type_options">
         <item>Single Choice</item>
         <item>Multi Choice</item>
-        <item>Short Answer</item>
-        <item>Long Answer</item>
     </string-array>
 </resources>

--- a/room-kit/src/main/res/values/strings.xml
+++ b/room-kit/src/main/res/values/strings.xml
@@ -250,4 +250,6 @@
     <string name="quiz_your_answer">Your Answer</string>
     <string name="hms_start_poll">Start Poll</string>
     <string name="hms_start_quiz">Start Quiz</string>
+    <string name="hms_name_this_poll">Name this poll</string>
+    <string name="hms_name_this_quiz">Name this quiz</string>
 </resources>

--- a/room-kit/src/main/res/values/strings.xml
+++ b/room-kit/src/main/res/values/strings.xml
@@ -245,7 +245,9 @@
     <string name="polls_answer_button">Vote</string>
     <string name="polls_answer_button_complete">Voted</string>
     <string name="polls_quiz_answer_button">Answer</string>
-po    <string name="polls_quiz_answer_button_complete">Answered</string>
+    <string name="polls_quiz_answer_button_complete">Answered</string>
     <string name="poll_title_heading">%1$s %2$s</string>
     <string name="quiz_your_answer">Your Answer</string>
+    <string name="hms_start_poll">Start Poll</string>
+    <string name="hms_start_quiz">Start Quiz</string>
 </resources>


### PR DESCRIPTION
- Refactor the question creator to hold state.
- Use state instead of volatile data in the view
- Update hms version
- Prevent crashes when saving
- Don't bring focus to options yet
- Unused imports
- Move interface position
- Extract QuestionUi sealed class to its own class
- Change text to figma
- Rearranged requiredToAnswer
- Fix UI
- Fix correct indices
- Address warning
- Correct validation
- Correct validation
- Fix option types
- Fix launch button
- Fix options
- Fix add option
- Fix delete option
- Fix direction
- cleanup
- Fix UI and logic about removing options
- Fix UI and question numbering logic
- Fix numbering
- UI fixes
- Fix only single option in recyclerview
- Consolidate question display
- Improve sorting via itemid
- Remove short and long answers
- Fix the item decorators increasing with time issue.
- Update imports
- Add/Edit
- Fix duplicate
- Fix numbering issue for delete
- Fix numbering for edit.
- Correct card background colours.
- Fix issues
- Fix issues
- Refresh validation when the option is deleted. If an empty option was deleted, it wasn't saying that the question is now valid.
