### PR TITLE
LIVE:1919 : Crashing in API < 24 on using activity?.isInPictureInPictureMode

### DIFF
--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
@@ -318,8 +318,10 @@ class MeetingFragment : Fragment() {
     private fun goToHomePage(details: HMSRemovedFromRoom? = null) {
 
         //only way to programmatically dismiss pip mode
-        if (activity?.isInPictureInPictureMode == true) {
-            activity?.moveTaskToBack(false)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            if (activity?.isInPictureInPictureMode == true) {
+                activity?.moveTaskToBack(false)
+            }
         }
 
         requireActivity().finish()
@@ -1045,11 +1047,15 @@ class MeetingFragment : Fragment() {
         handler.postDelayed(hideRunnable, delayMillis.toLong())
     }
 
-    @RequiresApi(Build.VERSION_CODES.N)
     private fun hideProgressBar() {
+        var isInPIPMode = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            if (activity?.isInPictureInPictureMode?.not() == true)
+                isInPIPMode = true
+        }
         binding.fragmentContainer.visibility = View.VISIBLE
         binding.bottomControls.visibility = View.VISIBLE
-        if (activity?.isInPictureInPictureMode?.not() == true && (meetingViewModel.meetingViewMode.value is MeetingViewMode.HLS_VIEWER).not()){
+        if (!isInPIPMode && (meetingViewModel.meetingViewMode.value is MeetingViewMode.HLS_VIEWER).not()){
             binding.bottomControls.visibility = View.VISIBLE
         }
         binding.progressBar.root.visibility = View.GONE

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/ActiveSpeakerFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/ActiveSpeakerFragment.kt
@@ -1,5 +1,6 @@
 package live.hms.roomkit.ui.meeting.activespeaker
 
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -127,7 +128,7 @@ class ActiveSpeakerFragment : VideoGridBaseFragment() {
 
   override fun onPause() {
 
-    if (activity?.isInPictureInPictureMode == true) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true) {
       //when it's pip mode don't unbind views
       wasLastModePip = true
       screenShareOverLocalVideoInGrid()
@@ -140,7 +141,7 @@ class ActiveSpeakerFragment : VideoGridBaseFragment() {
 
   private fun screenShareOverLocalVideoInGrid() {
     //hide video grid when screen share is shown!
-    binding.container.visibility = if (screenShareTrack != null && activity?.isInPictureInPictureMode == true) {
+    binding.container.visibility = if (screenShareTrack != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true) {
         View.GONE
     } else {
         View.VISIBLE

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -1,6 +1,7 @@
 package live.hms.roomkit.ui.meeting.commons
 
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -490,7 +491,7 @@ abstract class VideoGridBaseFragment : Fragment() {
    */
   private fun hideOrShowGridsForPip(onlyIndexToShow : Int? = null) {
     var showAtleastOne = false
-    if (activity?.isInPictureInPictureMode == true && onlyIndexToShow != null && renderedViews.size > 0) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true && onlyIndexToShow != null && renderedViews.size > 0) {
       renderedViews.forEachIndexed { index, renderedViewPair ->
         if (onlyIndexToShow == index && renderedViewPair.binding.root.isVisible.not()) {
           renderedViewPair.binding.root.visibility = View.VISIBLE
@@ -547,7 +548,7 @@ abstract class VideoGridBaseFragment : Fragment() {
 
   override fun onPause() {
     super.onPause()
-    if (activity?.isInPictureInPictureMode == true) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true) {
       wasLastModePip = true
       //force pip mode layout refresh
       hideOrShowGridsForPip(wasLastSpeakingViewIndex)


### PR DESCRIPTION
Added SDK version checks where ever we were using `activity?.isInPictureInPictureMode` 