### PR TITLE
AN-1247 hand not going down

### DIFF
--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -2224,9 +2224,25 @@ class MeetingViewModel(
             null
         }
     }
+    fun lowerRemotePeerHand(hmsPeer: HMSPeer, hmsActionResultListener: HMSActionResultListener)
+     = hmsSDK.lowerRemotePeerHand(hmsPeer, hmsActionResultListener)
 
     fun requestBringOnStage(handRaisePeer: HMSPeer, onStageRole: String) {
-        changeRole(handRaisePeer.peerID, onStageRole, prebuiltInfoContainer.shouldForceRoleChange())
+        val force = prebuiltInfoContainer.shouldForceRoleChange()
+        changeRole(handRaisePeer.peerID, onStageRole, force)
+
+        if(force) {
+            hmsSDK.lowerRemotePeerHand(handRaisePeer, object : HMSActionResultListener {
+                override fun onError(error: HMSException) {
+                    Log.d(TAG,"Failed to lower peer's hand $error")
+                }
+
+                override fun onSuccess() {
+                    Log.d(TAG,"Lowered peer's hand since the role was force changed")
+                }
+
+            })
+        }
     }
 
     fun triggerErrorNotification(message: String, isDismissible: Boolean = true, type: HMSNotificationType = HMSNotificationType.Error, actionButtonText:String ="") {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/participants/ParticipantPreviousRoleChangeUseCase.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/participants/ParticipantPreviousRoleChangeUseCase.kt
@@ -1,17 +1,18 @@
 package live.hms.roomkit.ui.meeting.participants
 
-import kotlinx.coroutines.CompletableDeferred
 import live.hms.roomkit.ui.meeting.CustomPeerMetadata
-import live.hms.video.error.HMSException
 import live.hms.video.sdk.HMSActionResultListener
-import live.hms.video.sdk.models.HMSLocalPeer
 import live.hms.video.sdk.models.HMSPeer
 
 class ParticipantPreviousRoleChangeUseCase(private val changeMetadata: (String, HMSActionResultListener) -> Unit) {
     fun getPreviousRole(peer: HMSPeer) : String? =
         CustomPeerMetadata.fromJson(peer.metadata)?.prevRole
 
-    fun setPreviousRole(peer : HMSPeer, roleName : String?, hmsActionResultListener: HMSActionResultListener, toggleHandraise : Boolean =false) {
+    fun setPreviousRole(
+        peer: HMSPeer,
+        roleName: String?,
+        hmsActionResultListener: HMSActionResultListener
+    ) {
         val existingMetadata = CustomPeerMetadata.fromJson(peer.metadata)
         // Set the role or create a new metadata object with it.
         val updatedMetadata = existingMetadata?.copy(prevRole = roleName,

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/participants/ParticipantsUseCase.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/participants/ParticipantsUseCase.kt
@@ -247,7 +247,8 @@ class ParticipantsUseCase(val meetingViewModel: MeetingViewModel,
                             meetingViewModel.prebuiltInfoContainer,
                             meetingViewModel.participantPreviousRoleChangeUseCase,
                             meetingViewModel::requestPeerLeave,
-                            meetingViewModel.activeSpeakers
+                            meetingViewModel.activeSpeakers,
+                            meetingViewModel::lowerRemotePeerHand
                         )
                     }!!)
                 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/role/RolePreviewFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/role/RolePreviewFragment.kt
@@ -98,32 +98,20 @@ class RolePreviewFragment : BottomSheetDialogFragment() {
         }
 
         binding.buttonJoinMeeting.setOnClickListener {
-            meetingViewModel.participantPreviousRoleChangeUseCase.setPreviousRole(meetingViewModel.hmsSDK.getLocalPeer()!!,
-                meetingViewModel.roleOnJoining?.name,
-                object : HMSActionResultListener {
-                    override fun onError(error: HMSException) {
-                        Log.e("RolePreviewFragment", "Error $error")
+            meetingViewModel.changeRoleAccept(onSuccess = {
+                contextSafe { context, activity ->
+                    activity.runOnUiThread {
+                        binding.previewView.removeTrack()
+                        meetingViewModel.lowerLocalPeerHand()
+                        findNavController().navigate(
+                            RolePreviewFragmentDirections.actionRolePreviewFragmentToMeetingFragment(
+                                false
+                            )
+                        )
+
                     }
-
-                    override fun onSuccess() {
-                        meetingViewModel.changeRoleAccept(onSuccess = {
-                            contextSafe { context, activity ->
-                                activity.runOnUiThread {
-                                    binding.previewView.removeTrack()
-                                    meetingViewModel.lowerLocalPeerHand()
-                                    findNavController().navigate(
-                                        RolePreviewFragmentDirections.actionRolePreviewFragmentToMeetingFragment(
-                                            false
-                                        )
-                                    )
-
-                                }
-                            }
-                        })
-                    }
-
-                }, toggleHandraise = true)
-
+                }
+            })
         }
 
         binding.declineButton.setOnClickListener {


### PR DESCRIPTION
- Update name and lower the hand as well
- Don't set the previous role info on the peer that changes the role...
- Always set previous role from the peer that got role changed
- Fix issue where there was a difference between raising hand and accepting, and not doing that.
