### PR TITLE
AN-1269 throw away changes for invalid indices in options

### DIFF
--- a/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/polls/PollQuestionViewHolder.kt
@@ -2,6 +2,7 @@ package live.hms.roomkit.ui.polls
 
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.View
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
@@ -123,11 +124,19 @@ class PollQuestionViewHolder<T : ViewBinding>(
                 it.onOptionTextChanged = { optionIndex, changedText ->
                     val question =
                         getItem(bindingAdapterPosition).currentQuestion as QuestionUi.ChoiceQuestions
-                    val changedList: List<String> = question.options.toMutableList().apply {
-                        this[optionIndex] = changedText
+                    val options = question.options
+                    if(optionIndex >= options.size)
+                        Log.e(TAG,"Skip invalid index change")
+                    else {
+                        val changedList: List<String> = options.toMutableList().apply {
+                            this[optionIndex] = changedText
+                        }
+                        question.options = changedList
+                        validateSaveButtonEnabledState(
+                            getItem(bindingAdapterPosition),
+                            binding.saveButton
+                        )
                     }
-                    question.options = changedList
-                    validateSaveButtonEnabledState(getItem(bindingAdapterPosition), binding.saveButton)
                 }
                 it.onSingleOptionSelected = { position ->
                     updateSelection(bindingAdapterPosition, listOf(position), null)


### PR DESCRIPTION
- Allow the build to complete and re-wire how settings works
- Turn off chat filtering
- Update UI
- Update UI
- Update UI
- Correct text for who sent messages
- Update MeetingViewModel.kt
- Remove inaccurate comment
- Update UI
- Update rbac when the selected user changes
- added changes
- When the user leaves, revert back to select a peer
- Fix issues with participants being seen as a header when there are none.
- Add "no recipients yet".
- leader board summary ui
- name section added
- Update LeaderBoardBottomSheetFragment.kt
- Update the participants in the bottomsheet when the role changes.
- Remove unused function
- added changes
- Fix warnings
- fixes
- fixes
- Update LeaderBoardBottomSheetFragment.kt
- fixes
- added changes
- added fix
- Don't close the fragment when roles change. The chat options will change on their own.
- Added description to the chat role selecting bottom sheet
- Add chat search
- Add chat search
- ui fixes
- fixes
- Add search fix ui
- Fix UI
- Fix participants tab UI
- fix text
- Settings fix, move unnecessary image
- added fix
- Update PrebuiltInfoContainer.kt
- Update PrebuiltInfoContainer.kt
- fixes
- Update LeaderBoardNameSection.kt
- added changes
- Update LeaderBoardBottomSheetFragment.kt
- Update LeaderBoardBottomSheetFragment.kt
- Update fragment_preview.xml
- Update LeaderBoardBottomSheetFragment.kt
- Update PrebuiltInfoContainer.kt
- Skip change if the text changes on an invalid index
