### PR TITLE
AN 1266 show stream has ended screen on hls viewer after the live stream is stopped

### DIFF
--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -1235,7 +1235,10 @@ class MeetingViewModel(
         var started = false
         val isHlsPeer = isHlsPeer(role)
         showAudioIcon.postValue(!isHlsPeer)
-        if (isHlsPeer && streamUrl != null) {
+        // If we don't check if the stream is started, it might try to open the hls view again when
+        //  the stream was stopped. This happens when a running stream is stopped and buffers
+        //  the stream.
+        if (isHlsPeer && streamUrl != null && streamingState.value != HMSStreamingState.STARTED) {
             started = true
             switchToHlsView(streamUrl)
         }


### PR DESCRIPTION
- Do not leave the meeting when HLS is stopped.
- Add stream ended
- Cleanup
- Close the button after stopping hls
- Don't restart hls stream if it's already started.
