### PR TITLE
AN 1378 on reconnection player is not resuming

### DIFF
--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
@@ -1102,7 +1102,6 @@ class MeetingFragment : Fragment() {
     private fun hideProgressBar() {
         var isInPIPMode = false
         binding.fragmentContainer.visibility = View.VISIBLE
-        binding.bottomControls.visibility = View.VISIBLE
         if (!isInPIPMode && (meetingViewModel.meetingViewMode.value is MeetingViewMode.HLS_VIEWER).not()){
             binding.bottomControls.visibility = View.VISIBLE
         }
@@ -1111,7 +1110,8 @@ class MeetingFragment : Fragment() {
 
     private fun showProgressBar() {
         binding.fragmentContainer.visibility = View.VISIBLE
-        binding.bottomControls.visibility = View.VISIBLE
+        if(meetingViewModel.meetingViewMode.value !is MeetingViewMode.HLS_VIEWER)
+            binding.bottomControls.visibility = View.VISIBLE
 
         binding.progressBar.root.visibility = View.VISIBLE
     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
@@ -237,11 +237,6 @@ private const val SECONDS_FROM_LIVE = 10
                 val progressBarVisibility by hlsViewModel.progressBarVisible.observeAsState()
                 val viewMode by meetingViewModel.state.observeAsState()
 
-                // Play the stream again after the websocket reconnects
-                LaunchedEffect(viewMode) {
-                    if(viewMode is MeetingState.Reconnected)
-                        player.play(args.hlsStreamUrl)
-                }
                 // Don't show whole view loading during the time it's disconnected or reconnecting.
                 if (progressBarVisibility == true || !(viewMode is MeetingState.Ongoing || viewMode is MeetingState.Reconnecting || viewMode is MeetingState.Reconnected || viewMode is MeetingState.Disconnecting || viewMode is MeetingState.Disconnected)) {
                     CircularProgressIndicator(

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
@@ -237,7 +237,13 @@ private const val SECONDS_FROM_LIVE = 10
                 val progressBarVisibility by hlsViewModel.progressBarVisible.observeAsState()
                 val viewMode by meetingViewModel.state.observeAsState()
 
-                if (progressBarVisibility == true || viewMode !is MeetingState.Ongoing) {
+                // Play the stream again after the websocket reconnects
+                LaunchedEffect(viewMode) {
+                    if(viewMode is MeetingState.Reconnected)
+                        player.play(args.hlsStreamUrl)
+                }
+                // Don't show whole view loading during the time it's disconnected or reconnecting.
+                if (progressBarVisibility == true || !(viewMode is MeetingState.Ongoing || viewMode is MeetingState.Reconnecting || viewMode is MeetingState.Reconnected || viewMode is MeetingState.Disconnecting || viewMode is MeetingState.Disconnected)) {
                     CircularProgressIndicator(
                         modifier = Modifier
                             .fillMaxSize()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsViewModel.kt
@@ -7,13 +7,10 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
-import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import live.hms.hls_player.HmsHlsCue
 import live.hms.hls_player.HmsHlsException
@@ -41,13 +38,6 @@ import live.hms.video.sdk.HMSSDK
     val player = HmsHlsPlayer(application, hmsSdk).apply {
         setListeners(this)
         play(hlsStreamUrl)
-        with(getNativePlayer()) {
-        trackSelectionParameters =
-            trackSelectionParameters
-                .buildUpon()
-                .setPreferredTextLanguage(trackSelectionParameters.preferredTextLanguages.firstOrNull())
-                .build()
-        }
     }
     private fun setListeners(player: HmsHlsPlayer) {
 //        binding.hlsView.player = player.getNativePlayer()
@@ -106,17 +96,5 @@ import live.hms.video.sdk.HMSSDK
             }
         })
 
-    }
-
-    fun allowZoom() {
-        isZoomEnabled.postValue(true)
-//        viewModelScope.launch {
-//            delay(400)
-//            resizeMode.postValue(RESIZE_MODE_ZOOM)
-//        }
-    }
-    private suspend fun checkLayers() {
-        delay(10_000)
-        player.getHmsHlsLayers()
     }
 }


### PR DESCRIPTION
- Cleanup
- Hiding the bottom bar in hls during and after reconnection. (reconnection|reconnected)
- Play again after the connection is restored.
