### PR TITLE
AN 1384 bottom menu is not coming for role if chat access is disabled

### DIFF
--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
@@ -872,7 +872,7 @@ fun HlsComposable(
 
 @Composable
 fun SessionOptionsButton(onClick: () -> Unit) {
-    Image(painter = painterResource(id = live.hms.roomkit.R.drawable.hls_hamburger_menu),
+    Image(painter = painterResource(id = live.hms.roomkit.R.drawable.compose_hls_hamburger_menu),
         contentDescription = "Menu",
         contentScale = ContentScale.None,
         modifier = Modifier


### PR DESCRIPTION
- Cleanup
- Hiding the bottom bar in hls during and after reconnection. (reconnection|reconnected)
- Play again after the connection is restored.
- We don't need to play again after an error because there won't be one and hlsplayer will keep retrying.
- Add buttons for disabled chat
- Use the correct drawable for compose's settings
