### PR TITLE
do not try to preserve hls in reconnecting states

### DIFF
--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
@@ -237,7 +237,7 @@ private const val SECONDS_FROM_LIVE = 10
                 val viewMode by meetingViewModel.state.observeAsState()
 
                 // Don't show whole view loading during the time it's disconnected or reconnecting.
-                if (progressBarVisibility == true || !(viewMode is MeetingState.Ongoing || viewMode is MeetingState.Reconnecting || viewMode is MeetingState.Reconnected || viewMode is MeetingState.Disconnecting || viewMode is MeetingState.Disconnected)) {
+                if (progressBarVisibility == true || viewMode !is MeetingState.Ongoing) {
                     CircularProgressIndicator(
                         modifier = Modifier
                             .fillMaxSize()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
@@ -48,6 +48,7 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.Center
@@ -245,7 +246,7 @@ private const val SECONDS_FROM_LIVE = 10
                         color = PrimaryDefault
                     )
                 } else {
-                    val isChatEnabled by remember { mutableStateOf(meetingViewModel.prebuiltInfoContainer.isChatEnabled()) }
+                    val isChatEnabled by rememberSaveable { mutableStateOf(meetingViewModel.prebuiltInfoContainer.isChatEnabled()) }
                     var chatOpen by remember { mutableStateOf(isChatEnabled)}
                     val isHandRaised by meetingViewModel.isHandRaised.observeAsState(false)
 


### PR DESCRIPTION
- Do not try to preserve chat state
- Save the isChatEnabled values so it can be restored if killed.
