### PR TITLE
Gradle 8.2 upgrade

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,6 +8,7 @@ plugins {
 }
 android {
     compileSdk 34
+    namespace = "live.hms.app2"
 
     defaultConfig {
         applicationId "live.hms.app2"
@@ -41,13 +42,14 @@ android {
 
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
     compileOptions {
-        sourceCompatibility = "1.8"
-        targetCompatibility = "1.8"
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Jetpack Navigation

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 10 17:14:29 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/prebuilt-themes/build.gradle.kts
+++ b/prebuilt-themes/build.gradle.kts
@@ -27,11 +27,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
 

--- a/room-kit/build.gradle
+++ b/room-kit/build.gradle
@@ -39,19 +39,18 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     buildFeatures {
         viewBinding true
-        dataBinding {
-            enabled true
-        }
+        dataBinding true
         compose true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.4.8"

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/ClosedCaptionsForEveryone.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/ClosedCaptionsForEveryone.kt
@@ -152,7 +152,7 @@ fun EnableCaptionsDisplay(onEnableForEveryoneClicked : () -> Unit,
                 text = screen.title, style = TextStyle(
                     fontSize = 20.sp,
                     lineHeight = 24.sp,
-                    fontFamily = FontFamily(Font(R.font.inter_bold)),
+                    fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_bold)),
                     fontWeight = FontWeight(600),
                     color = Variables.OnSecondaryHigh,
                     letterSpacing = 0.15.sp,
@@ -206,7 +206,7 @@ fun EnableButton(
             style = TextStyle(
                 fontSize = 16.sp,
                 lineHeight = 24.sp,
-                fontFamily = FontFamily(Font(R.font.inter_bold)),
+                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_bold)),
                 fontWeight = FontWeight(600),
                 color = Variables.OnPrimaryHigh,
                 textAlign = TextAlign.Center,
@@ -225,7 +225,7 @@ fun DescriptionText(text : String) {
         style = TextStyle(
             fontSize = 14.sp,
             lineHeight = 20.sp,
-            fontFamily = FontFamily(Font(R.font.inter_regular)),
+            fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
             fontWeight = FontWeight(400),
             color = Variables.OnSurfaceMedium,
             letterSpacing = 0.25.sp,

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/SwitchRoleBottomSheet.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/SwitchRoleBottomSheet.kt
@@ -175,7 +175,7 @@ fun SwitchComponent(
 ) {
     fun getDescriptionText(): AnnotatedString {
         val nameStyle = SpanStyle(
-            fontFamily = FontFamily(Font(R.font.inter_bold)),
+            fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_bold)),
         )
         return buildAnnotatedString {
 
@@ -222,7 +222,7 @@ fun SwitchComponent(
                 modifier = Modifier.weight(1f), text = "Switch Role", style = TextStyle(
                     fontSize = 20.sp,
                     lineHeight = 24.sp,
-                    fontFamily = FontFamily(Font(R.font.inter_bold)),
+                    fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_bold)),
                     fontWeight = FontWeight(600),
                     color = Variables.OnSecondaryHigh,
                     letterSpacing = 0.15.sp,
@@ -242,7 +242,7 @@ fun SwitchComponent(
             modifier = Modifier.fillMaxWidth(), text = getDescriptionText(), style = TextStyle(
                 fontSize = 14.sp,
                 lineHeight = 20.sp,
-                fontFamily = FontFamily(Font(R.font.inter_regular)),
+                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                 fontWeight = FontWeight(400),
                 color = Variables.OnSurfaceMedium,
                 letterSpacing = 0.25.sp,
@@ -311,7 +311,7 @@ fun SpinnerText(it: String, modifier: Modifier) {
         text = it, modifier, style = TextStyle(
             fontSize = 16.sp,
             lineHeight = 24.sp,
-            fontFamily = FontFamily(Font(R.font.inter_regular)),
+            fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
             fontWeight = FontWeight(400),
             color = Variables.OnSurfaceHigh
         )
@@ -388,7 +388,7 @@ fun ChangeRoleButton(
             style = TextStyle(
                 fontSize = 16.sp,
                 lineHeight = 24.sp,
-                fontFamily = FontFamily(Font(R.font.inter_bold)),
+                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_bold)),
                 fontWeight = FontWeight(600),
                 color = Variables.OnPrimaryHigh,
                 textAlign = TextAlign.Center,

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/TranscriptionUseCase.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/TranscriptionUseCase.kt
@@ -152,11 +152,11 @@ data class TranscriptViewHolder(
         }
     fun getSubtitle() : AnnotatedString {
         return buildAnnotatedString {
-            withStyle(style = SpanStyle(fontFamily = FontFamily(Font(R.font.inter_bold)))) {
+            withStyle(style = SpanStyle(fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_bold)))) {
                 append(peerName)
                 append(": ")
             }
-            withStyle(style = SpanStyle(fontFamily = FontFamily(Font(R.font.inter_regular)))) {
+            withStyle(style = SpanStyle(fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)))) {
                 append(text)
             }
         }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
@@ -583,7 +583,7 @@ fun ChatHeader(
                         "About Session",
                         fontSize = 16.sp,
                         lineHeight = 24.sp,
-                        fontFamily = FontFamily(Font(R.font.inter_semibold)),
+                        fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_semibold)),
                         fontWeight = FontWeight(600),
                         color = OnSurfaceHigh,
                         letterSpacing = 0.15.sp,
@@ -613,7 +613,7 @@ fun ChatHeader(
 
                 GlideImage(
                     model = logoUrl,
-                    loading = if (LocalInspectionMode.current) placeholder(R.drawable.exo_edit_mode_logo) else null,
+                    loading = if (LocalInspectionMode.current) placeholder(androidx.media3.ui.R.drawable.exo_edit_mode_logo) else null,
                     contentDescription = "Logo"
                 )
                 Column {
@@ -622,7 +622,7 @@ fun ChatHeader(
                             it, style = TextStyle(
                                 fontSize = 14.sp,
                                 lineHeight = 20.sp,
-                                fontFamily = FontFamily(Font(R.font.inter_regular)),
+                                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                                 fontWeight = FontWeight(600),
                                 color = Variables.OnSecondaryHigh,
                                 letterSpacing = 0.1.sp,
@@ -633,13 +633,13 @@ fun ChatHeader(
                     Row(horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start)) {
                         val textStyle = SpanStyle(
                             fontSize = 12.sp,
-                            fontFamily = FontFamily(Font(R.font.inter_regular)),
+                            fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                             fontWeight = FontWeight(400),
                             color = Variables.OnSurfaceMedium,
                             letterSpacing = 0.4.sp,
                         )
                         val moreStyle = SpanStyle(
-                                fontFamily = FontFamily(Font(R.font.inter_semibold)),
+                                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_semibold)),
                                 fontSize = 12.sp,
                                 fontWeight = FontWeight(600),
                                 color = OnSurfaceHigh,
@@ -677,7 +677,7 @@ fun ChatHeader(
                     text = description,
                     fontSize = 14.sp,
                     lineHeight = 20.sp,
-                    fontFamily = FontFamily(Font(R.font.inter_regular)),
+                    fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                     fontWeight = FontWeight(400),
                     color = Variables.OnSurfaceMedium,
                 )
@@ -757,7 +757,7 @@ fun ChatMessage(name: String, message: String) {
             name, style = TextStyle(
                 fontSize = 14.sp,
                 lineHeight = 20.sp,
-                fontFamily = FontFamily(Font(R.font.inter_regular)),
+                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                 fontWeight = FontWeight(600),
                 color = OnSurfaceHigh,
                 letterSpacing = 0.1.sp,
@@ -767,7 +767,7 @@ fun ChatMessage(name: String, message: String) {
             message, style = TextStyle(
                 fontSize = 14.sp,
                 lineHeight = 20.sp,
-                fontFamily = FontFamily(Font(R.font.inter_regular)),
+                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                 fontWeight = FontWeight(400),
                 color = OnSurfaceHigh,
                 letterSpacing = 0.25.sp,
@@ -834,7 +834,7 @@ fun GoLiveText(isLive : Boolean, behindBy: String, goLiveClicked : () -> Unit) {
             style = TextStyle(
                 fontSize = 16.sp,
                 lineHeight = 24.sp,
-                fontFamily = FontFamily(Font(R.font.inter_regular)),
+                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                 fontWeight = FontWeight(600),
                 color = if(isLive) OnSurfaceHigh else Variables.OnSurfaceMedium,
                 letterSpacing = 0.5.sp,
@@ -849,7 +849,7 @@ fun GoLiveText(isLive : Boolean, behindBy: String, goLiveClicked : () -> Unit) {
                 style = TextStyle(
                     fontSize = 16.sp,
                     lineHeight = 24.sp,
-                    fontFamily = FontFamily(Font(R.font.inter_regular)),
+                    fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                     fontWeight = FontWeight(600),
                     color = if(isLive) OnSurfaceHigh else Variables.OnSurfaceMedium,
                     letterSpacing = 0.5.sp,
@@ -893,6 +893,7 @@ fun SettingsButton(
 //    }
 //}
 
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @OptIn(ExperimentalComposeUiApi::class)
 @UnstableApi
 @Composable
@@ -1013,7 +1014,7 @@ fun HlsComposable(
                                 style = TextStyle(
                                     fontSize = 11.sp,
                                     lineHeight = 13.sp,
-                                    fontFamily = FontFamily(Font(R.font.inter_semibold)),
+                                    fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_semibold)),
                                     color = Color.White,
                                     letterSpacing = 0.5.sp,
                                 )
@@ -1426,7 +1427,7 @@ fun HlsChatIcon(chatEnabled: Boolean, unreadMessages :Int?, buttonClicked: () ->
                     lineHeight = 16.sp,
                     color = OnSurfaceHigh,
                     fontSize = 10.sp,
-                    fontFamily = FontFamily(Font(R.font.inter_regular)),
+                    fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                     fontWeight = FontWeight(600),
                     textAlign = TextAlign.Center,
                 )

--- a/vb-prebuilt/build.gradle.kts
+++ b/vb-prebuilt/build.gradle.kts
@@ -27,11 +27,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 
     buildFeatures {

--- a/vb-prebuilt/src/main/java/live/hms/vb_prebuilt/VirtualBackgroundOptions.kt
+++ b/vb-prebuilt/src/main/java/live/hms/vb_prebuilt/VirtualBackgroundOptions.kt
@@ -124,7 +124,7 @@ fun VirtualBackgroundOptions(
             text = "Effects", style = TextStyle(
                 fontSize = 14.sp,
                 lineHeight = 24.sp,
-                fontFamily = FontFamily(Font(R.font.inter_regular)),
+                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                 fontWeight = FontWeight(600),
                 color = Variables.OnSecondaryHigh,
                 letterSpacing = 0.15.sp,
@@ -187,7 +187,7 @@ fun VirtualBackgroundOptions(
                 style = TextStyle(
                     fontSize = 14.sp,
                     lineHeight = 20.sp,
-                    fontFamily = FontFamily(Font(R.font.inter_bold)),
+                    fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_bold)),
                     fontWeight = FontWeight(600),
                     color = Variables.OnSurfaceHigh,
                     letterSpacing = 0.1.sp,
@@ -276,7 +276,7 @@ fun BottomSheetHeader(close : () -> Unit,) {
             text = "Virtual Background", style = TextStyle(
                 fontSize = 16.sp,
                 lineHeight = 24.sp,
-                fontFamily = FontFamily(Font(R.font.inter_bold)),
+                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_bold)),
                 fontWeight = FontWeight(600),
                 color = Variables.OnSecondaryHigh,
                 letterSpacing = 0.15.sp,
@@ -287,7 +287,7 @@ fun BottomSheetHeader(close : () -> Unit,) {
                 .padding(1.dp)
                 .size(24.dp)
                 .clickable { close() },
-            painter = painterResource(id = R.drawable.outline_cross),
+            painter = painterResource(id = live.hms.prebuilt_themes.R.drawable.outline_cross),
             contentDescription = "Close",
             contentScale = ContentScale.None
         )
@@ -325,7 +325,7 @@ fun VbOptionButton(@DrawableRes drawable :  Int,
             style = TextStyle(
                 fontSize = 12.sp,
                 lineHeight = 16.sp,
-                fontFamily = FontFamily(Font(R.font.inter_regular)),
+                fontFamily = FontFamily(Font(live.hms.prebuilt_themes.R.font.inter_regular)),
                 fontWeight = FontWeight(400),
                 color = Variables.OnSurfaceMedium,
                 letterSpacing = 0.4.sp,


### PR DESCRIPTION
	•	Upgraded Gradle and AGP to version 8.2.
	•	Updated JVM target and JDK compile options to version 17.
	•	Added namespace (as required by Gradle).

Note: A drawable is missing in HlsFragment (line 616) when building with version 8.2:

`loading = if (LocalInspectionMode.current) placeholder(R.drawable.exo_edit_mode_logo) else null
`

For now, this has been set to null. Please adjust this change according to your requirements.

We performed a basic sanity check on this PR. Please ensure that the appropriate QA processes are added.