### PR TITLE
Fix PreviewFragment's Null-Localpeer crash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,7 @@ kotlin.code.style=official
 100MS_APP_VERSION_CODE=381
 100MS_APP_VERSION_NAME=5.0.16
 hmsRoomKitGroup=live.100ms
-#TODO: change the room kit version before pushing/merging final code
-HMS_ROOM_KIT_VERSION=1.3.2
+HMS_ROOM_KIT_VERSION=1.3.3
 HMS_SDK_VERSION=2.9.79
 # Common publishing info
 publishing_licence_name="MIT License"

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,11 +17,12 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-100MS_APP_VERSION_CODE=380
-100MS_APP_VERSION_NAME=5.0.15
+100MS_APP_VERSION_CODE=381
+100MS_APP_VERSION_NAME=5.0.16
 hmsRoomKitGroup=live.100ms
+#TODO: change the room kit version before pushing/merging final code
 HMS_ROOM_KIT_VERSION=1.3.2
-HMS_SDK_VERSION=2.9.78
+HMS_SDK_VERSION=2.9.79
 # Common publishing info
 publishing_licence_name="MIT License"
 publishing_licence_url="http://www.opensource.org/licenses/mit-license.php"

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/PreviewFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/PreviewFragment.kt
@@ -106,7 +106,7 @@ class PreviewFragment : Fragment() {
             if (binding.buttonJoinMeeting.drawableStart == null) {
                 binding.buttonJoinMeeting.setDrawables(
                     start = ContextCompat.getDrawable(
-                        context!!, R.drawable.ic_live
+                        requireContext(), R.drawable.ic_live
                     )
                 )
             }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/PreviewFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/PreviewFragment.kt
@@ -667,7 +667,16 @@ class PreviewFragment : Fragment() {
                 enableDisableJoinNowButton()
 
                     updateUiBasedOnPublishParams(room.localPeer?.hmsRole?.publishParams)
-                track = MeetingTrack(room.localPeer!!, null, null)
+
+                // Guard against null localPeer during SDK initialization race condition.
+                // Return early to prevent NPE crash - UI will update via other lifecycle events
+                val localPeer = room.localPeer
+                if (localPeer == null) {
+                    Log.e(TAG, "LocalPeer is null in previewUpdateLiveData observer, skipping video initialization")
+                    return@Observer
+                }
+
+                track = MeetingTrack(localPeer, null, null)
                 localTracks.forEach {
                     when (it) {
                         is HMSLocalAudioTrack -> {
@@ -687,8 +696,8 @@ class PreviewFragment : Fragment() {
 
                 binding.editTextName.doOnTextChanged { text, start, before, count ->
                     if (text.isNullOrEmpty().not()) {
-                        val intitals = kotlin.runCatching { NameUtils.getInitials(text.toString()) }
-                        binding.nameInitials.text = intitals.getOrNull().orEmpty()
+                        val initials = kotlin.runCatching { NameUtils.getInitials(text.toString()) }
+                        binding.nameInitials.text = initials.getOrNull().orEmpty()
                         binding.noNameIv.visibility = View.GONE
                     } else {
                         binding.nameInitials.text = ""


### PR DESCRIPTION
### What does this PR do?
This peer fixes the NPE handling inside the PreviewFragment and also upgrades the HMSSDK to 2.9.79.