### PR TITLE
Foreground services implementation

### DIFF
--- a/app/src/main/java/live/hms/app2/ui/home/HomeFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/home/HomeFragment.kt
@@ -27,6 +27,7 @@ import live.hms.app2.util.isValidMeetingUrl
 import live.hms.app2.util.viewLifecycle
 import live.hms.roomkit.ui.HMSPrebuiltOptions
 import live.hms.roomkit.ui.HMSRoomKit
+import live.hms.roomkit.ui.notification.CallNotificationConfig
 import live.hms.roomkit.ui.meeting.DeviceStatsBottomSheet
 import live.hms.roomkit.ui.meeting.LEAVE_INFORMATION_PERSON
 import live.hms.roomkit.ui.meeting.LEAVE_INFORMATION_REASON
@@ -163,15 +164,28 @@ class HomeFragment : Fragment() {
 
             val consistentUserId = getConsistentUserIdOverSessions()
 
+            // Configure notification for foreground service when app is backgrounded during a call
+            val callNotificationConfig = CallNotificationConfig(
+                smallIcon = R.drawable.ic_launcher_foreground,
+                largeIcon = live.hms.roomkit.R.drawable.ic_bars_24,
+                title = "A Call is in progress",
+                text = "Click here to return to your IMPORTANT call"
+            )
+
             HMSRoomKit.launchPrebuilt(
-                code, activity, HMSPrebuiltOptions(userName = if(settings.setInitialNameFromClient) getUsername() else null, userId = consistentUserId, debugInfo = settings.inPreBuiltDebugMode,
+                code, activity, HMSPrebuiltOptions(
+                    userName = if(settings.setInitialNameFromClient) getUsername() else null,
+                    userId = consistentUserId,
+                    debugInfo = settings.inPreBuiltDebugMode,
+                    callNotificationConfig = callNotificationConfig,
                     endPoints = hashMapOf<String, String>().apply {
                         if (settings.environment.contains("prod").not()) {
                             put("token", "https://auth-nonprod.100ms.live")
                             put("init", "https://qa-init.100ms.live/init")
                             put("layout", "https://api-nonprod.100ms.live")
                         }
-                    })
+                    }
+                )
             )
         }
     }

--- a/app/src/main/java/live/hms/app2/ui/home/HomeFragment.kt
+++ b/app/src/main/java/live/hms/app2/ui/home/HomeFragment.kt
@@ -166,10 +166,8 @@ class HomeFragment : Fragment() {
 
             // Configure notification for foreground service when app is backgrounded during a call
             val callNotificationConfig = CallNotificationConfig(
-                smallIcon = R.drawable.ic_launcher_foreground,
-                largeIcon = live.hms.roomkit.R.drawable.ic_bars_24,
                 title = "A Call is in progress",
-                text = "Click here to return to your IMPORTANT call"
+                text = "Tap to return to your call"
             )
 
             HMSRoomKit.launchPrebuilt(

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,10 +17,10 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-100MS_APP_VERSION_CODE=381
-100MS_APP_VERSION_NAME=5.0.16
+100MS_APP_VERSION_CODE=382
+100MS_APP_VERSION_NAME=5.0.17
 hmsRoomKitGroup=live.100ms
-HMS_ROOM_KIT_VERSION=1.3.3
+HMS_ROOM_KIT_VERSION=1.3.4
 HMS_SDK_VERSION=2.9.79
 # Common publishing info
 publishing_licence_name="MIT License"

--- a/room-kit/src/main/AndroidManifest.xml
+++ b/room-kit/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
@@ -34,6 +35,11 @@
             android:screenOrientation="portrait"
             android:theme="@style/Theme.Roomkit.NoActionBar"
             android:windowSoftInputMode="stateAlwaysHidden|adjustResize" />
+
+        <service
+            android:name=".ui.meeting.CallForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="microphone" />
 
     </application>
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/HMSPrebuiltOptions.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/HMSPrebuiltOptions.kt
@@ -2,6 +2,7 @@ package live.hms.roomkit.ui
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import live.hms.roomkit.ui.notification.CallNotificationConfig
 
 
 @Parcelize
@@ -10,4 +11,5 @@ data class HMSPrebuiltOptions(
     val userId: String? = null,
     val endPoints: HashMap<String, String>? = null,
     val debugInfo: Boolean = false,
+    val callNotificationConfig: CallNotificationConfig? = null,
 ) : Parcelable

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -107,13 +107,29 @@ class CallForegroundService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
+        // Convert vector drawable to bitmap for large icon (video camera = meeting indicator)
+        val largeIconBitmap = androidx.core.graphics.drawable.DrawableCompat.wrap(
+            androidx.core.content.ContextCompat.getDrawable(this, R.drawable.ic_camera_toggle_off)!!
+        ).let { drawable ->
+            val bitmap = android.graphics.Bitmap.createBitmap(
+                drawable.intrinsicWidth,
+                drawable.intrinsicHeight,
+                android.graphics.Bitmap.Config.ARGB_8888
+            )
+            val canvas = android.graphics.Canvas(bitmap)
+            drawable.setBounds(0, 0, canvas.width, canvas.height)
+            drawable.draw(canvas)
+            bitmap
+        }
+
         return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.call_notification_title))
             .setContentText(getString(R.string.call_notification_text))
-            .setSmallIcon(R.drawable.ic_mic_24)
+            .setSmallIcon(R.drawable.ic_app_logo)
+            .setLargeIcon(largeIconBitmap)
             .setOngoing(true)
             .setContentIntent(pendingIntent)
-            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setCategory(NotificationCompat.CATEGORY_CALL)
             .build()
     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -20,6 +20,12 @@ import live.hms.roomkit.ui.notification.CallNotificationConfig
  * This prevents Android 14+ from aggressively suspending network sockets.
  *
  * The service displays a persistent notification allowing users to return to the call.
+ *
+ * Usage:
+ * - Call start() when user joins a meeting (while app is in foreground)
+ * - Call updateNotification() with showDescription=true when app goes to background
+ * - Call updateNotification() with showDescription=false when app comes to foreground
+ * - Call stop() when user leaves the meeting
  */
 class CallForegroundService : Service() {
 
@@ -33,15 +39,19 @@ class CallForegroundService : Service() {
         private const val EXTRA_TEXT = "extra_text"
         private const val EXTRA_CHANNEL_NAME = "extra_channel_name"
         private const val EXTRA_CHANNEL_DESCRIPTION = "extra_channel_description"
+        private const val EXTRA_SHOW_DESCRIPTION = "extra_show_description"
+
+        private const val ACTION_UPDATE_NOTIFICATION = "action_update_notification"
 
         /**
-         * Start the foreground service with optional custom notification config.
-         * Call this from MeetingActivity.onStop() when user is in an active meeting.
+         * Start the foreground service when user joins a meeting.
+         * Should be called while app is in foreground to satisfy Android 14+ requirements.
          *
          * @param context The context to start the service from
          * @param config Optional notification configuration for custom branding
+         * @param showDescription Whether to show the notification description text
          */
-        fun start(context: Context, config: CallNotificationConfig? = null) {
+        fun start(context: Context, config: CallNotificationConfig? = null, showDescription: Boolean = false) {
             val intent = Intent(context, CallForegroundService::class.java).apply {
                 config?.let {
                     it.smallIcon?.let { icon -> putExtra(EXTRA_SMALL_ICON, icon) }
@@ -51,6 +61,7 @@ class CallForegroundService : Service() {
                     it.channelName?.let { name -> putExtra(EXTRA_CHANNEL_NAME, name) }
                     it.channelDescription?.let { desc -> putExtra(EXTRA_CHANNEL_DESCRIPTION, desc) }
                 }
+                putExtra(EXTRA_SHOW_DESCRIPTION, showDescription)
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent)
@@ -60,8 +71,24 @@ class CallForegroundService : Service() {
         }
 
         /**
+         * Update the notification to show or hide description.
+         * Call with showDescription=true when app goes to background.
+         * Call with showDescription=false when app comes to foreground.
+         *
+         * @param context The context
+         * @param showDescription Whether to show the notification description text
+         */
+        fun updateNotification(context: Context, showDescription: Boolean) {
+            val intent = Intent(context, CallForegroundService::class.java).apply {
+                action = ACTION_UPDATE_NOTIFICATION
+                putExtra(EXTRA_SHOW_DESCRIPTION, showDescription)
+            }
+            context.startService(intent)
+        }
+
+        /**
          * Stop the foreground service.
-         * Call this from MeetingActivity.onStart() or when leaving the meeting.
+         * Call this when user leaves the meeting.
          */
         fun stop(context: Context) {
             val intent = Intent(context, CallForegroundService::class.java)
@@ -76,12 +103,22 @@ class CallForegroundService : Service() {
     private var notificationText: String? = null
     private var channelName: String? = null
     private var channelDescription: String? = null
+    private var showDescription: Boolean = false
+
+    private var isServiceStarted = false
 
     override fun onCreate() {
         super.onCreate()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_UPDATE_NOTIFICATION) {
+            // Just update the notification, don't restart the service
+            showDescription = intent.getBooleanExtra(EXTRA_SHOW_DESCRIPTION, false)
+            updateNotificationDisplay()
+            return START_NOT_STICKY
+        }
+
         // Extract config from intent
         intent?.let {
             smallIconRes = it.getIntExtra(EXTRA_SMALL_ICON, R.drawable.ic_app_logo)
@@ -90,6 +127,7 @@ class CallForegroundService : Service() {
             notificationText = it.getStringExtra(EXTRA_TEXT)
             channelName = it.getStringExtra(EXTRA_CHANNEL_NAME)
             channelDescription = it.getStringExtra(EXTRA_CHANNEL_DESCRIPTION)
+            showDescription = it.getBooleanExtra(EXTRA_SHOW_DESCRIPTION, false)
         }
 
         // Create channel after extracting config (channel name may be customized)
@@ -97,14 +135,24 @@ class CallForegroundService : Service() {
 
         val notification = createNotification()
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(
-                NOTIFICATION_ID,
-                notification,
-                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-            )
-        } else {
-            startForeground(NOTIFICATION_ID, notification)
+        if (!isServiceStarted) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    startForeground(
+                        NOTIFICATION_ID,
+                        notification,
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                    )
+                } else {
+                    startForeground(NOTIFICATION_ID, notification)
+                }
+                isServiceStarted = true
+            } catch (e: SecurityException) {
+                // On Android 14+, MICROPHONE type may fail if app is not in eligible state
+                // Log the error and stop the service gracefully instead of crashing
+                android.util.Log.e("CallFGService", "Failed to start foreground service with MICROPHONE type", e)
+                stopSelf()
+            }
         }
 
         return START_NOT_STICKY
@@ -115,7 +163,16 @@ class CallForegroundService : Service() {
     @RequiresApi(Build.VERSION_CODES.N)
     override fun onDestroy() {
         super.onDestroy()
+        isServiceStarted = false
         stopForeground(STOP_FOREGROUND_REMOVE)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun updateNotificationDisplay() {
+        if (isServiceStarted) {
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager.notify(NOTIFICATION_ID, createNotification())
+        }
     }
 
     private fun createNotificationChannel() {
@@ -162,15 +219,20 @@ class CallForegroundService : Service() {
             bitmap
         }
 
-        return NotificationCompat.Builder(this, CHANNEL_ID)
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(notificationTitle ?: getString(R.string.call_notification_title))
-            .setContentText(notificationText ?: getString(R.string.call_notification_text))
             .setSmallIcon(smallIconRes)
             .setLargeIcon(largeIconBitmap)
             .setOngoing(true)
             .setContentIntent(pendingIntent)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setCategory(NotificationCompat.CATEGORY_CALL)
-            .build()
+
+        // Only show description text when app is in background
+        if (showDescription) {
+            builder.setContentText(notificationText ?: getString(R.string.call_notification_text))
+        }
+
+        return builder.build()
     }
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -1,20 +1,120 @@
 package live.hms.roomkit.ui.meeting
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
+import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.os.IBinder
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
+import live.hms.roomkit.R
 
 /**
  * Foreground service to keep the app alive during an active call when backgrounded.
- * This prevents Android 14+ from suspending network sockets.
+ * This prevents Android 14+ from aggressively suspending network sockets.
  *
- * TODO: Implement in Phase 2
+ * The service displays a persistent notification allowing users to return to the call.
  */
 class CallForegroundService : Service() {
 
-    override fun onBind(intent: Intent?): IBinder? = null
+    companion object {
+        private const val CHANNEL_ID = "hms_call_channel"
+        private const val NOTIFICATION_ID = 100
+
+        /**
+         * Start the foreground service.
+         * Call this from MeetingActivity.onStop() when user is in an active meeting.
+         */
+        fun start(context: Context) {
+            val intent = Intent(context, CallForegroundService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        /**
+         * Stop the foreground service.
+         * Call this from MeetingActivity.onStart() or when leaving the meeting.
+         */
+        fun stop(context: Context) {
+            val intent = Intent(context, CallForegroundService::class.java)
+            context.stopService(intent)
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannel()
+    }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val notification = createNotification()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(
+                NOTIFICATION_ID,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+            )
+        } else {
+            startForeground(NOTIFICATION_ID, notification)
+        }
+
         return START_NOT_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    override fun onDestroy() {
+        super.onDestroy()
+        stopForeground(STOP_FOREGROUND_REMOVE)
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.call_notification_channel_name),
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = getString(R.string.call_notification_channel_description)
+                setShowBadge(false)
+            }
+
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun createNotification(): Notification {
+        // Create intent to return to MeetingActivity when notification is tapped
+        val tapIntent = Intent(this, MeetingActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            tapIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.call_notification_title))
+            .setContentText(getString(R.string.call_notification_text))
+            .setSmallIcon(R.drawable.ic_mic_24)
+            .setOngoing(true)
+            .setContentIntent(pendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setCategory(NotificationCompat.CATEGORY_CALL)
+            .build()
     }
 }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -13,6 +13,7 @@ import android.os.IBinder
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import live.hms.roomkit.R
+import live.hms.roomkit.ui.notification.CallNotificationConfig
 
 /**
  * Foreground service to keep the app alive during an active call when backgrounded.
@@ -26,12 +27,31 @@ class CallForegroundService : Service() {
         private const val CHANNEL_ID = "hms_call_channel"
         private const val NOTIFICATION_ID = 100
 
+        private const val EXTRA_SMALL_ICON = "extra_small_icon"
+        private const val EXTRA_LARGE_ICON = "extra_large_icon"
+        private const val EXTRA_TITLE = "extra_title"
+        private const val EXTRA_TEXT = "extra_text"
+        private const val EXTRA_CHANNEL_NAME = "extra_channel_name"
+        private const val EXTRA_CHANNEL_DESCRIPTION = "extra_channel_description"
+
         /**
-         * Start the foreground service.
+         * Start the foreground service with optional custom notification config.
          * Call this from MeetingActivity.onStop() when user is in an active meeting.
+         *
+         * @param context The context to start the service from
+         * @param config Optional notification configuration for custom branding
          */
-        fun start(context: Context) {
-            val intent = Intent(context, CallForegroundService::class.java)
+        fun start(context: Context, config: CallNotificationConfig? = null) {
+            val intent = Intent(context, CallForegroundService::class.java).apply {
+                config?.let {
+                    it.smallIcon?.let { icon -> putExtra(EXTRA_SMALL_ICON, icon) }
+                    it.largeIcon?.let { icon -> putExtra(EXTRA_LARGE_ICON, icon) }
+                    it.title?.let { title -> putExtra(EXTRA_TITLE, title) }
+                    it.text?.let { text -> putExtra(EXTRA_TEXT, text) }
+                    it.channelName?.let { name -> putExtra(EXTRA_CHANNEL_NAME, name) }
+                    it.channelDescription?.let { desc -> putExtra(EXTRA_CHANNEL_DESCRIPTION, desc) }
+                }
+            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent)
             } else {
@@ -49,12 +69,32 @@ class CallForegroundService : Service() {
         }
     }
 
+    // Config values extracted from intent
+    private var smallIconRes: Int = R.drawable.ic_app_logo
+    private var largeIconRes: Int = R.drawable.ic_camera_toggle_off
+    private var notificationTitle: String? = null
+    private var notificationText: String? = null
+    private var channelName: String? = null
+    private var channelDescription: String? = null
+
     override fun onCreate() {
         super.onCreate()
-        createNotificationChannel()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Extract config from intent
+        intent?.let {
+            smallIconRes = it.getIntExtra(EXTRA_SMALL_ICON, R.drawable.ic_app_logo)
+            largeIconRes = it.getIntExtra(EXTRA_LARGE_ICON, R.drawable.ic_camera_toggle_off)
+            notificationTitle = it.getStringExtra(EXTRA_TITLE)
+            notificationText = it.getStringExtra(EXTRA_TEXT)
+            channelName = it.getStringExtra(EXTRA_CHANNEL_NAME)
+            channelDescription = it.getStringExtra(EXTRA_CHANNEL_DESCRIPTION)
+        }
+
+        // Create channel after extracting config (channel name may be customized)
+        createNotificationChannel()
+
         val notification = createNotification()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -82,10 +122,10 @@ class CallForegroundService : Service() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
                 CHANNEL_ID,
-                getString(R.string.call_notification_channel_name),
+                channelName ?: getString(R.string.call_notification_channel_name),
                 NotificationManager.IMPORTANCE_LOW
             ).apply {
-                description = getString(R.string.call_notification_channel_description)
+                description = channelDescription ?: getString(R.string.call_notification_channel_description)
                 setShowBadge(false)
             }
 
@@ -107,9 +147,9 @@ class CallForegroundService : Service() {
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
-        // Convert vector drawable to bitmap for large icon (video camera = meeting indicator)
+        // Convert drawable to bitmap for large icon
         val largeIconBitmap = androidx.core.graphics.drawable.DrawableCompat.wrap(
-            androidx.core.content.ContextCompat.getDrawable(this, R.drawable.ic_camera_toggle_off)!!
+            androidx.core.content.ContextCompat.getDrawable(this, largeIconRes)!!
         ).let { drawable ->
             val bitmap = android.graphics.Bitmap.createBitmap(
                 drawable.intrinsicWidth,
@@ -123,9 +163,9 @@ class CallForegroundService : Service() {
         }
 
         return NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle(getString(R.string.call_notification_title))
-            .setContentText(getString(R.string.call_notification_text))
-            .setSmallIcon(R.drawable.ic_app_logo)
+            .setContentTitle(notificationTitle ?: getString(R.string.call_notification_title))
+            .setContentText(notificationText ?: getString(R.string.call_notification_text))
+            .setSmallIcon(smallIconRes)
             .setLargeIcon(largeIconBitmap)
             .setOngoing(true)
             .setContentIntent(pendingIntent)

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -14,6 +14,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import live.hms.roomkit.R
 import live.hms.roomkit.ui.notification.CallNotificationConfig
+import androidx.core.graphics.createBitmap
 
 /**
  * Foreground service to keep the app alive during an active call when backgrounded.
@@ -111,6 +112,7 @@ class CallForegroundService : Service() {
         super.onCreate()
     }
 
+    @RequiresApi(Build.VERSION_CODES.M)
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_UPDATE_NOTIFICATION) {
             // Just update the notification, don't restart the service
@@ -208,11 +210,7 @@ class CallForegroundService : Service() {
         val largeIconBitmap = androidx.core.graphics.drawable.DrawableCompat.wrap(
             androidx.core.content.ContextCompat.getDrawable(this, largeIconRes)!!
         ).let { drawable ->
-            val bitmap = android.graphics.Bitmap.createBitmap(
-                drawable.intrinsicWidth,
-                drawable.intrinsicHeight,
-                android.graphics.Bitmap.Config.ARGB_8888
-            )
+            val bitmap = createBitmap(drawable.intrinsicWidth, drawable.intrinsicHeight)
             val canvas = android.graphics.Canvas(bitmap)
             drawable.setBounds(0, 0, canvas.width, canvas.height)
             drawable.draw(canvas)

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -1,0 +1,20 @@
+package live.hms.roomkit.ui.meeting
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+
+/**
+ * Foreground service to keep the app alive during an active call when backgrounded.
+ * This prevents Android 14+ from suspending network sockets.
+ *
+ * TODO: Implement in Phase 2
+ */
+class CallForegroundService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        return START_NOT_STICKY
+    }
+}

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -58,6 +58,26 @@ class MeetingActivity : AppCompatActivity() {
         )
     }
 
+    // Track if user is in an active meeting (non-HLS) for foreground service
+    private var isInActiveMeeting = false
+
+    /**
+     * Updates the active meeting state based on joined status and participant type.
+     * Called when either joined or showAudioIcon LiveData changes.
+     * - joined: true when user has joined the meeting
+     * - showAudioIcon: true for regular participants, false for HLS viewers
+     */
+    private fun updateActiveMeetingState() {
+        val joined = meetingViewModel.joined.value == true
+        val isRegularParticipant = meetingViewModel.showAudioIcon.value == true
+        isInActiveMeeting = joined && isRegularParticipant
+
+        // If user left the meeting while in background, stop the service
+        if (!joined) {
+            CallForegroundService.stop(this)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         _binding = ActivityMeetingBinding.inflate(layoutInflater)
@@ -105,12 +125,34 @@ class MeetingActivity : AppCompatActivity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        // App came to foreground - stop the foreground service
+        CallForegroundService.stop(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        // App going to background - start foreground service if in active meeting
+        // Don't start if activity is finishing (user leaving) or if user is HLS viewer
+        if (isInActiveMeeting && !isFinishing) {
+            CallForegroundService.start(this)
+        }
+    }
+
     override fun onDestroy() {
         super.onDestroy()
+        // Ensure service is stopped when activity is destroyed
+        CallForegroundService.stop(this)
         _binding = null
     }
 
     private fun initObservers() {
+        // Track active meeting state for foreground service
+        // showAudioIcon is true for regular participants, false for HLS viewers
+        meetingViewModel.joined.observe(this) { updateActiveMeetingState() }
+        meetingViewModel.showAudioIcon.observe(this) { updateActiveMeetingState() }
+
         meetingViewModel.recordingState.observe(this) {
             invalidateOptionsMenu()
         }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -26,6 +26,7 @@ import live.hms.roomkit.ui.notification.CardStackListener
 import live.hms.roomkit.ui.notification.Direction
 import live.hms.roomkit.ui.notification.HMSNotification
 import live.hms.roomkit.ui.notification.HMSNotificationAdapter
+ import live.hms.roomkit.ui.notification.CallNotificationConfig
 import live.hms.roomkit.ui.notification.HMSNotificationDiffCallBack
 import live.hms.roomkit.ui.notification.HMSNotificationType
 import live.hms.roomkit.ui.polls.display.PollDisplayFragment
@@ -60,6 +61,9 @@ class MeetingActivity : AppCompatActivity() {
 
     // Track if user is in an active meeting (non-HLS) for foreground service
     private var isInActiveMeeting = false
+
+    // Notification config from HMSPrebuiltOptions for foreground service
+    private var callNotificationConfig: CallNotificationConfig? = null
 
     /**
      * Updates the active meeting state based on joined status and participant type.
@@ -97,6 +101,9 @@ class MeetingActivity : AppCompatActivity() {
 
         val hmsPrebuiltOption: HMSPrebuiltOptions? =
             intent!!.extras!![ROOM_PREBUILT] as? HMSPrebuiltOptions
+
+        // Store notification config for foreground service
+        callNotificationConfig = hmsPrebuiltOption?.callNotificationConfig
 
         val roomCode: String = intent?.getStringExtra(ROOM_CODE)?:""
         val token: String = intent?.getStringExtra(TOKEN)?:""
@@ -136,7 +143,7 @@ class MeetingActivity : AppCompatActivity() {
         // App going to background - start foreground service if in active meeting
         // Don't start if activity is finishing (user leaving) or if user is HLS viewer
         if (isInActiveMeeting && !isFinishing) {
-            CallForegroundService.start(this)
+            CallForegroundService.start(this, callNotificationConfig)
         }
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -1,12 +1,16 @@
 package live.hms.roomkit.ui.meeting
 
 import android.Manifest.permission.POST_NOTIFICATIONS
+import android.Manifest.permission.RECORD_AUDIO
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -142,8 +146,21 @@ class MeetingActivity : AppCompatActivity() {
         super.onStop()
         // App going to background - start foreground service if in active meeting
         // Don't start if activity is finishing (user leaving) or if user is HLS viewer
-        if (isInActiveMeeting && !isFinishing) {
-            CallForegroundService.start(this, callNotificationConfig)
+        // Also check RECORD_AUDIO permission - required for FOREGROUND_SERVICE_TYPE_MICROPHONE
+        val hasAudioPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            checkSelfPermission(RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true // Permissions are granted at install time pre-M
+        }
+
+        android.util.Log.d("CallFGService", "onStop: isInActiveMeeting=$isInActiveMeeting, isFinishing=$isFinishing, hasAudioPermission=$hasAudioPermission")
+
+        if (isInActiveMeeting && !isFinishing && hasAudioPermission) {
+            try {
+                CallForegroundService.start(this, callNotificationConfig)
+            } catch (e: Exception) {
+                android.util.Log.e("CallFGService", "Failed to start foreground service", e)
+            }
         }
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -149,8 +149,15 @@ class MeetingActivity : AppCompatActivity() {
         lifecycleScope.launch {
             meetingViewModel.events.collect { event ->
                 if (event is MeetingViewModel.Event.RequestPermission) {
-                    requestedPermissions = event.permissions
-                    requestPermissionLauncher.launch(event.permissions)
+                    // Add POST_NOTIFICATIONS to the permission request on Android 13+
+                    // This is needed for foreground service notification to be visible
+                    val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        event.permissions + POST_NOTIFICATIONS
+                    } else {
+                        event.permissions
+                    }
+                    requestedPermissions = permissions
+                    requestPermissionLauncher.launch(permissions)
                 }
             }
         }
@@ -385,13 +392,20 @@ class MeetingActivity : AppCompatActivity() {
 
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
-    ) {
-        if (it.containsKey(POST_NOTIFICATIONS)) {
+    ) { results ->
+        // Check if this was a screenshare-only permission request (only POST_NOTIFICATIONS)
+        val isScreensharePermissionRequest = results.size == 1 && results.containsKey(POST_NOTIFICATIONS)
+        if (isScreensharePermissionRequest) {
             meetingViewModel.screenshareRequest.value = Unit
+            return@registerForActivityResult
         }
-        // Do not prevent joining if bluetooth connect is denied.
-        else if (it.values.all { granted -> granted }) meetingViewModel.permissionGranted()
-        else {
+
+        // For meeting permissions, check if critical permissions (excluding POST_NOTIFICATIONS) are granted
+        // POST_NOTIFICATIONS is optional - meeting works without it, just notification won't show
+        val criticalPermissions = results.filterKeys { it != POST_NOTIFICATIONS }
+        if (criticalPermissions.values.all { granted -> granted }) {
+            meetingViewModel.permissionGranted()
+        } else {
             // Leave the meeting
             meetingViewModel.leaveMeeting(null)
             // Close our activity to return to whatever the user had before

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -74,14 +74,34 @@ class MeetingActivity : AppCompatActivity() {
      * Called when either joined or showAudioIcon LiveData changes.
      * - joined: true when user has joined the meeting
      * - showAudioIcon: true for regular participants, false for HLS viewers
+     *
+     * Starts the foreground service when user joins (while app is in foreground)
      */
     private fun updateActiveMeetingState() {
         val joined = meetingViewModel.joined.value == true
         val isRegularParticipant = meetingViewModel.showAudioIcon.value == true
+        val wasInActiveMeeting = isInActiveMeeting
         isInActiveMeeting = joined && isRegularParticipant
 
-        // If user left the meeting while in background, stop the service
-        if (!joined) {
+        // Start service when user joins meeting (while app is still in foreground)
+        if (isInActiveMeeting && !wasInActiveMeeting) {
+            val hasAudioPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                checkSelfPermission(RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
+            } else {
+                true
+            }
+            if (hasAudioPermission) {
+                try {
+                    // Start with showDescription=false since app is in foreground
+                    CallForegroundService.start(this, callNotificationConfig, showDescription = false)
+                } catch (e: Exception) {
+                    android.util.Log.e("CallFGService", "Failed to start foreground service on join", e)
+                }
+            }
+        }
+
+        // Stop service when user leaves the meeting
+        if (!isInActiveMeeting && wasInActiveMeeting) {
             CallForegroundService.stop(this)
         }
     }
@@ -138,29 +158,18 @@ class MeetingActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
-        // App came to foreground - stop the foreground service
-        CallForegroundService.stop(this)
+        // App came to foreground - update notification to hide description
+        if (isInActiveMeeting) {
+            CallForegroundService.updateNotification(this, showDescription = false)
+        }
     }
 
     override fun onStop() {
         super.onStop()
-        // App going to background - start foreground service if in active meeting
-        // Don't start if activity is finishing (user leaving) or if user is HLS viewer
-        // Also check RECORD_AUDIO permission - required for FOREGROUND_SERVICE_TYPE_MICROPHONE
-        val hasAudioPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            checkSelfPermission(RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
-        } else {
-            true // Permissions are granted at install time pre-M
-        }
-
-        android.util.Log.d("CallFGService", "onStop: isInActiveMeeting=$isInActiveMeeting, isFinishing=$isFinishing, hasAudioPermission=$hasAudioPermission")
-
-        if (isInActiveMeeting && !isFinishing && hasAudioPermission) {
-            try {
-                CallForegroundService.start(this, callNotificationConfig)
-            } catch (e: Exception) {
-                android.util.Log.e("CallFGService", "Failed to start foreground service", e)
-            }
+        // App going to background - update notification to show description
+        // Don't update if activity is finishing (user leaving)
+        if (isInActiveMeeting && !isFinishing) {
+            CallForegroundService.updateNotification(this, showDescription = true)
         }
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -2,6 +2,7 @@ package live.hms.roomkit.ui.meeting
 
 import android.Manifest
 import android.app.Application
+import android.app.PendingIntent
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.Matrix
@@ -1726,6 +1727,12 @@ class MeetingViewModel(
                         && track.type == HMSTrackType.VIDEO)
             ) {
                 _tracks.remove(meetingTrack)
+
+                // Update isScreenShare when local peer's screenshare track is removed
+                // This handles the case when user stops screenshare via notification action button
+                if (peer.isLocal && track.source == HMSTrackSource.SCREEN && track.type == HMSTrackType.VIDEO) {
+                    isScreenShare.postValue(false)
+                }
             }
 
             // Update the view as some track has been removed

--- a/room-kit/src/main/java/live/hms/roomkit/ui/notification/CallNotificationConfig.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/notification/CallNotificationConfig.kt
@@ -1,0 +1,41 @@
+package live.hms.roomkit.ui.notification
+
+import android.os.Parcelable
+import androidx.annotation.DrawableRes
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Configuration for the foreground service notification shown when the app is backgrounded
+ * during an active call.
+ *
+ * Integrating apps can customize the notification to match their branding.
+ *
+ * Example usage:
+ * ```kotlin
+ * HMSPrebuiltOptions(
+ *     callNotificationConfig = CallNotificationConfig(
+ *         smallIcon = R.drawable.my_app_logo,
+ *         title = "MyApp - Call Active",
+ *         text = "Tap to return to your call"
+ *     )
+ * )
+ * ```
+ *
+ * @param smallIcon Drawable resource for the small icon shown in status bar and notification header.
+ *                  Should be a monochrome icon for best results. If null, uses default icon.
+ * @param largeIcon Drawable resource for the large icon shown on the right side of notification.
+ *                  Can be a full-color icon. If null, uses default icon.
+ * @param title     Notification title. If null, uses "Call in progress".
+ * @param text      Notification body text. If null, uses "Tap to return to the call".
+ * @param channelName Name for the notification channel. If null, uses "Ongoing Call".
+ * @param channelDescription Description for the notification channel. If null, uses default.
+ */
+@Parcelize
+data class CallNotificationConfig(
+    @DrawableRes val smallIcon: Int? = null,
+    @DrawableRes val largeIcon: Int? = null,
+    val title: String? = null,
+    val text: String? = null,
+    val channelName: String? = null,
+    val channelDescription: String? = null
+) : Parcelable

--- a/room-kit/src/main/res/values/strings.xml
+++ b/room-kit/src/main/res/values/strings.xml
@@ -279,4 +279,10 @@
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="toggle_vb">Toggle VB</string>
+
+    <!-- Call Foreground Service Notification -->
+    <string name="call_notification_channel_name">Ongoing Call</string>
+    <string name="call_notification_channel_description">Shows when you\'re in an active call</string>
+    <string name="call_notification_title">Call in progress</string>
+    <string name="call_notification_text">Tap to return to the call</string>
 </resources>


### PR DESCRIPTION
### Add Foreground Service for Background Audio

  Adds a foreground service to prevent audio disconnection when the app is backgrounded on Android 14+.

  **Changes**

  - Add CallForegroundService with microphone foreground service type
  - Start service when user joins meeting (satisfies Android 14 "eligible state" requirement)
  - Update notification to show description only when app is backgrounded
  - Add CallNotificationConfig to HMSPrebuiltOptions for custom notification branding
  - Request POST_NOTIFICATIONS permission alongside camera/mic permissions on Android 13+
  - No foreground service for HLS viewers

  - ** This PR also includes a small bugfix of stopsharing in-app notification not closing when screen sharing is stopped from notification button.
 
  **New Public API**

  HMSPrebuiltOptions(
      callNotificationConfig = CallNotificationConfig(
          smallIcon = R.drawable.my_icon,
          title = "Call in progress",
          text = "Tap to return"
      )
  )

**where CallNotificationConfig is:** 

data class CallNotificationConfig(
    @DrawableRes val smallIcon: Int? = null,
    @DrawableRes val largeIcon: Int? = null,
    val title: String? = null,
    val text: String? = null,
    val channelName: String? = null,
    val channelDescription: String? = null
) : Parcelable