### PR TITLE
Fix foreground service

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ kotlin.code.style=official
 100MS_APP_VERSION_CODE=382
 100MS_APP_VERSION_NAME=5.0.17
 hmsRoomKitGroup=live.100ms
-HMS_ROOM_KIT_VERSION=1.3.5
+HMS_ROOM_KIT_VERSION=1.3.6
 HMS_SDK_VERSION=2.9.79
 # Common publishing info
 publishing_licence_name="MIT License"

--- a/room-kit/src/main/AndroidManifest.xml
+++ b/room-kit/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
@@ -39,7 +40,7 @@
         <service
             android:name=".ui.meeting.CallForegroundService"
             android:exported="false"
-            android:foregroundServiceType="microphone" />
+            android:foregroundServiceType="microphone|mediaPlayback" />
 
     </application>
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -142,22 +142,30 @@ class CallForegroundService : Service() {
 
         if (!isServiceStarted) {
             try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    // Check if we have microphone permission to determine service type
-                    val hasMicPermission = checkSelfPermission(RECORD_AUDIO) ==
-                        PackageManager.PERMISSION_GRANTED
-                    val serviceType = if (hasMicPermission) {
-                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-                    } else {
-                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                when {
+                    // Android 11+ (API 30+): Use MICROPHONE or MEDIA_PLAYBACK based on permission
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> {
+                        val hasMicPermission = checkSelfPermission(RECORD_AUDIO) ==
+                            PackageManager.PERMISSION_GRANTED
+                        val serviceType = if (hasMicPermission) {
+                            ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                        } else {
+                            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                        }
+                        startForeground(NOTIFICATION_ID, notification, serviceType)
                     }
-                    startForeground(
-                        NOTIFICATION_ID,
-                        notification,
-                        serviceType
-                    )
-                } else {
-                    startForeground(NOTIFICATION_ID, notification)
+                    // Android 10 (API 29): Use MEDIA_PLAYBACK only (MICROPHONE not available)
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
+                        startForeground(
+                            NOTIFICATION_ID,
+                            notification,
+                            ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                        )
+                    }
+                    // Android 9 and below: No service type needed
+                    else -> {
+                        startForeground(NOTIFICATION_ID, notification)
+                    }
                 }
                 isServiceStarted = true
             } catch (e: SecurityException) {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -1,5 +1,6 @@
 package live.hms.roomkit.ui.meeting
 
+import android.Manifest.permission.RECORD_AUDIO
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -7,9 +8,11 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import live.hms.roomkit.R
@@ -140,21 +143,32 @@ class CallForegroundService : Service() {
         if (!isServiceStarted) {
             try {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    // Check if we have microphone permission to determine service type
+                    val hasMicPermission = checkSelfPermission(RECORD_AUDIO) ==
+                        PackageManager.PERMISSION_GRANTED
+                    val serviceType = if (hasMicPermission) {
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                    } else {
+                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+                    }
+                    Log.d("CallFGService", "Using service type: ${if (hasMicPermission) "MICROPHONE" else "MEDIA_PLAYBACK"}")
                     startForeground(
                         NOTIFICATION_ID,
                         notification,
-                        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                        serviceType
                     )
                 } else {
                     startForeground(NOTIFICATION_ID, notification)
                 }
                 isServiceStarted = true
+                Log.d("CallFGService", "Foreground service started successfully")
             } catch (e: SecurityException) {
-                // On Android 14+, MICROPHONE type may fail if app is not in eligible state
-                // Log the error and stop the service gracefully instead of crashing
-                android.util.Log.e("CallFGService", "Failed to start foreground service with MICROPHONE type", e)
+                // On Android 14+, service type may fail if app is not in eligible state
+                Log.e("CallFGService", "Failed to start foreground service", e)
                 stopSelf()
             }
+        } else {
+            Log.d("CallFGService", "Service already started, skipping startForeground")
         }
 
         return START_NOT_STICKY

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -37,6 +37,13 @@ class CallForegroundService : Service() {
         private const val CHANNEL_ID = "hms_call_channel"
         private const val NOTIFICATION_ID = 100
 
+        /**
+         * Flag to check if the foreground service is running.
+         * Used by HLS player to determine if it should pause when app goes to background.
+         */
+        var isRunning: Boolean = false
+            private set
+
         private const val EXTRA_SMALL_ICON = "extra_small_icon"
         private const val EXTRA_LARGE_ICON = "extra_large_icon"
         private const val EXTRA_TITLE = "extra_title"
@@ -168,6 +175,7 @@ class CallForegroundService : Service() {
                     }
                 }
                 isServiceStarted = true
+                isRunning = true
             } catch (e: SecurityException) {
                 // On Android 14+, service type may fail if app is not in eligible state
                 Log.e("CallFGService", "Failed to start foreground service", e)
@@ -186,6 +194,7 @@ class CallForegroundService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         isServiceStarted = false
+        isRunning = false
         stopForeground(STOP_FOREGROUND_REMOVE)
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -151,7 +151,6 @@ class CallForegroundService : Service() {
                     } else {
                         ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
                     }
-                    Log.d("CallFGService", "Using service type: ${if (hasMicPermission) "MICROPHONE" else "MEDIA_PLAYBACK"}")
                     startForeground(
                         NOTIFICATION_ID,
                         notification,
@@ -161,7 +160,6 @@ class CallForegroundService : Service() {
                     startForeground(NOTIFICATION_ID, notification)
                 }
                 isServiceStarted = true
-                Log.d("CallFGService", "Foreground service started successfully")
             } catch (e: SecurityException) {
                 // On Android 14+, service type may fail if app is not in eligible state
                 Log.e("CallFGService", "Failed to start foreground service", e)

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -102,8 +102,6 @@ class MeetingActivity : AppCompatActivity() {
         val wasInActiveMeeting = isInActiveMeeting
         isInActiveMeeting = joined
 
-        Log.d("CallFGService", "updateActiveMeetingState: joined=$joined, wasInActiveMeeting=$wasInActiveMeeting, isInActiveMeeting=$isInActiveMeeting")
-
         // Start service when user joins meeting (while app is still in foreground)
         if (isInActiveMeeting && !wasInActiveMeeting) {
             try {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.view.WindowManager
 import android.widget.Toast
@@ -101,17 +102,17 @@ class MeetingActivity : AppCompatActivity() {
         val wasInActiveMeeting = isInActiveMeeting
         isInActiveMeeting = joined
 
-        android.util.Log.d("CallFGService", "updateActiveMeetingState: joined=$joined, wasInActiveMeeting=$wasInActiveMeeting, isInActiveMeeting=$isInActiveMeeting")
+        Log.d("CallFGService", "updateActiveMeetingState: joined=$joined, wasInActiveMeeting=$wasInActiveMeeting, isInActiveMeeting=$isInActiveMeeting")
 
         // Start service when user joins meeting (while app is still in foreground)
         if (isInActiveMeeting && !wasInActiveMeeting) {
             try {
                 CallForegroundService.start(this, callNotificationConfig, showDescription = false)
             } catch (e: Exception) {
-                android.util.Log.e("CallFGService", "Failed to start foreground service on join", e)
+                Log.e("CallFGService", "Failed to start foreground service on join", e)
             }
         } else {
-            android.util.Log.d("CallFGService", "Not starting service: isInActiveMeeting=$isInActiveMeeting, wasInActiveMeeting=$wasInActiveMeeting")
+           Log.d("CallFGService", "Not starting service: isInActiveMeeting=$isInActiveMeeting, wasInActiveMeeting=$wasInActiveMeeting")
         }
 
         // Stop service when user leaves the meeting

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -1,9 +1,9 @@
 package live.hms.roomkit.ui.meeting
 
 import android.Manifest.permission.POST_NOTIFICATIONS
-import android.Manifest.permission.RECORD_AUDIO
 import android.content.pm.PackageManager
 import android.os.Build
+import androidx.core.content.ContextCompat
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
@@ -69,35 +69,49 @@ class MeetingActivity : AppCompatActivity() {
     // Notification config from HMSPrebuiltOptions for foreground service
     private var callNotificationConfig: CallNotificationConfig? = null
 
+    // Launcher for requesting notification permission on Android 13+
+    private val notificationPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { _ ->
+        // Permission result doesn't affect flow - service will start regardless. Notification just won't show if permission was denied
+    }
+
+
+    // Request POST_NOTIFICATIONS permission on Android 13+ if not already granted.
+    private fun requestNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val hasPermission = ContextCompat.checkSelfPermission(
+                this,
+                POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+
+            if (!hasPermission) {
+                notificationPermissionLauncher.launch(POST_NOTIFICATIONS)
+            }
+        }
+    }
+
     /**
-     * Updates the active meeting state based on joined status and participant type.
-     * Called when either joined or showAudioIcon LiveData changes.
-     * - joined: true when user has joined the meeting
-     * - showAudioIcon: true for regular participants, false for HLS viewers
-     *
-     * Starts the foreground service when user joins (while app is in foreground)
+     * Updates the active meeting state based on joined status.
+     * Starts the foreground service when user joins (any role).
+     * Uses MICROPHONE type for users with mic permission, MEDIA_PLAYBACK for viewers.
      */
     private fun updateActiveMeetingState() {
         val joined = meetingViewModel.joined.value == true
-        val isRegularParticipant = meetingViewModel.showAudioIcon.value == true
         val wasInActiveMeeting = isInActiveMeeting
-        isInActiveMeeting = joined && isRegularParticipant
+        isInActiveMeeting = joined
+
+        android.util.Log.d("CallFGService", "updateActiveMeetingState: joined=$joined, wasInActiveMeeting=$wasInActiveMeeting, isInActiveMeeting=$isInActiveMeeting")
 
         // Start service when user joins meeting (while app is still in foreground)
         if (isInActiveMeeting && !wasInActiveMeeting) {
-            val hasAudioPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                checkSelfPermission(RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED
-            } else {
-                true
+            try {
+                CallForegroundService.start(this, callNotificationConfig, showDescription = false)
+            } catch (e: Exception) {
+                android.util.Log.e("CallFGService", "Failed to start foreground service on join", e)
             }
-            if (hasAudioPermission) {
-                try {
-                    // Start with showDescription=false since app is in foreground
-                    CallForegroundService.start(this, callNotificationConfig, showDescription = false)
-                } catch (e: Exception) {
-                    android.util.Log.e("CallFGService", "Failed to start foreground service on join", e)
-                }
-            }
+        } else {
+            android.util.Log.d("CallFGService", "Not starting service: isInActiveMeeting=$isInActiveMeeting, wasInActiveMeeting=$wasInActiveMeeting")
         }
 
         // Stop service when user leaves the meeting
@@ -112,6 +126,9 @@ class MeetingActivity : AppCompatActivity() {
         setContentView(binding.root)
         supportActionBar?.setDisplayShowTitleEnabled(false)
         settingsStore = SettingsStore(this)
+
+        // Request notification permission on Android 13+ for foreground service notification
+        requestNotificationPermissionIfNeeded()
 
         val deferringInsetsListener = RootViewDeferringInsetsCallback(
             persistentInsetTypes = WindowInsetsCompat.Type.systemBars(),
@@ -188,11 +205,8 @@ class MeetingActivity : AppCompatActivity() {
     }
 
     private fun initObservers() {
-        // Track active meeting state for foreground service
-        // showAudioIcon is true for regular participants, false for HLS viewers
+        // Start foreground service when user joins the meeting (any role)
         meetingViewModel.joined.observe(this) { updateActiveMeetingState() }
-        meetingViewModel.showAudioIcon.observe(this) { updateActiveMeetingState() }
-
         meetingViewModel.recordingState.observe(this) {
             invalidateOptionsMenu()
         }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
@@ -112,6 +112,7 @@ import live.hms.roomkit.databinding.HlsFragmentLayoutBinding
 import live.hms.roomkit.databinding.LayoutChatMergeBinding
 import live.hms.roomkit.hideKeyboard
 import live.hms.roomkit.setOnSingleClickListener
+import live.hms.roomkit.ui.meeting.CallForegroundService
 import live.hms.roomkit.ui.meeting.ClosedCaptionsForEveryone
 import live.hms.roomkit.ui.meeting.HlsVideoQualitySelectorBottomSheet
 import live.hms.roomkit.ui.meeting.MeetingFragment
@@ -1442,7 +1443,10 @@ fun PauseWhenLeaving(player : HmsHlsPlayer, playInstead :() -> Unit) {
         when(event)
         {
             Lifecycle.Event.ON_PAUSE -> {
-                player.pause()
+                // Only pause if foreground service is NOT running  - This allows HLS audio to continue playing in background
+                if (!CallForegroundService.isRunning) {
+                    player.pause()
+                }
             }
 
             Lifecycle.Event.ON_RESUME -> {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
@@ -1458,6 +1458,10 @@ fun PauseWhenLeaving(player : HmsHlsPlayer, playInstead :() -> Unit) {
                 }
             }
 
+            Lifecycle.Event.ON_DESTROY -> {
+                player.stop()
+            }
+
             else -> {}
         }
     }


### PR DESCRIPTION
### Summary

  - Enable HLS audio playback in background for viewers, stop it when app gets killed
  - Fix foreground service type for Android 10 (use MEDIA_PLAYBACK instead of MICROPHONE)
  - Start foreground service for all joined users, not just those with mic permission


###   Changes

  - Add FOREGROUND_SERVICE_MEDIA_PLAYBACK permission and service type
  - Use MEDIA_PLAYBACK for viewers/Android 10, MICROPHONE for participants with mic permission on Android 11+
  - Track foreground service state to prevent HLS player from pausing when app backgrounds, stop only on app kill
  - Bump room-kit version to 1.3.6