### PR TITLE
Fix foreground service notification issues and MeetingActivity null pointer crash 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ kotlin.code.style=official
 100MS_APP_VERSION_CODE=382
 100MS_APP_VERSION_NAME=5.0.17
 hmsRoomKitGroup=live.100ms
-HMS_ROOM_KIT_VERSION=1.3.6
+HMS_ROOM_KIT_VERSION=1.3.7
 HMS_SDK_VERSION=2.9.79
 # Common publishing info
 publishing_licence_name="MIT License"

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/CallForegroundService.kt
@@ -16,7 +16,11 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import live.hms.roomkit.R
+import live.hms.roomkit.ui.HMSPrebuiltOptions
 import live.hms.roomkit.ui.notification.CallNotificationConfig
+import live.hms.roomkit.util.ROOM_CODE
+import live.hms.roomkit.util.ROOM_PREBUILT
+import live.hms.roomkit.util.TOKEN
 import androidx.core.graphics.createBitmap
 
 /**
@@ -51,6 +55,9 @@ class CallForegroundService : Service() {
         private const val EXTRA_CHANNEL_NAME = "extra_channel_name"
         private const val EXTRA_CHANNEL_DESCRIPTION = "extra_channel_description"
         private const val EXTRA_SHOW_DESCRIPTION = "extra_show_description"
+        private const val EXTRA_ROOM_CODE = "extra_room_code"
+        private const val EXTRA_TOKEN = "extra_token"
+        private const val EXTRA_PREBUILT_OPTIONS = "extra_prebuilt_options"
 
         private const val ACTION_UPDATE_NOTIFICATION = "action_update_notification"
 
@@ -61,8 +68,18 @@ class CallForegroundService : Service() {
          * @param context The context to start the service from
          * @param config Optional notification configuration for custom branding
          * @param showDescription Whether to show the notification description text
+         * @param roomCode The room code for the meeting (used for notification tap intent)
+         * @param token The auth token for the meeting (used for notification tap intent)
+         * @param prebuiltOptions The prebuilt options (used for notification tap intent)
          */
-        fun start(context: Context, config: CallNotificationConfig? = null, showDescription: Boolean = false) {
+        fun start(
+            context: Context,
+            config: CallNotificationConfig? = null,
+            showDescription: Boolean = false,
+            roomCode: String? = null,
+            token: String? = null,
+            prebuiltOptions: HMSPrebuiltOptions? = null
+        ) {
             val intent = Intent(context, CallForegroundService::class.java).apply {
                 config?.let {
                     it.smallIcon?.let { icon -> putExtra(EXTRA_SMALL_ICON, icon) }
@@ -73,6 +90,10 @@ class CallForegroundService : Service() {
                     it.channelDescription?.let { desc -> putExtra(EXTRA_CHANNEL_DESCRIPTION, desc) }
                 }
                 putExtra(EXTRA_SHOW_DESCRIPTION, showDescription)
+                // Pass meeting info for notification tap intent
+                roomCode?.let { putExtra(EXTRA_ROOM_CODE, it) }
+                token?.let { putExtra(EXTRA_TOKEN, it) }
+                prebuiltOptions?.let { putExtra(EXTRA_PREBUILT_OPTIONS, it) }
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 context.startForegroundService(intent)
@@ -116,6 +137,11 @@ class CallForegroundService : Service() {
     private var channelDescription: String? = null
     private var showDescription: Boolean = false
 
+    // Meeting info for notification tap intent
+    private var meetingRoomCode: String? = null
+    private var meetingToken: String? = null
+    private var meetingPrebuiltOptions: HMSPrebuiltOptions? = null
+
     private var isServiceStarted = false
 
     override fun onCreate() {
@@ -140,6 +166,15 @@ class CallForegroundService : Service() {
             channelName = it.getStringExtra(EXTRA_CHANNEL_NAME)
             channelDescription = it.getStringExtra(EXTRA_CHANNEL_DESCRIPTION)
             showDescription = it.getBooleanExtra(EXTRA_SHOW_DESCRIPTION, false)
+            // Extract meeting info for notification tap intent
+            meetingRoomCode = it.getStringExtra(EXTRA_ROOM_CODE)
+            meetingToken = it.getStringExtra(EXTRA_TOKEN)
+            meetingPrebuiltOptions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                it.getParcelableExtra(EXTRA_PREBUILT_OPTIONS, HMSPrebuiltOptions::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                it.getParcelableExtra(EXTRA_PREBUILT_OPTIONS)
+            }
         }
 
         // Create channel after extracting config (channel name may be customized)
@@ -224,8 +259,12 @@ class CallForegroundService : Service() {
 
     private fun createNotification(): Notification {
         // Create intent to return to MeetingActivity when notification is tapped
+        // Include meeting info so activity can be properly recreated if it was destroyed
         val tapIntent = Intent(this, MeetingActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            meetingRoomCode?.let { putExtra(ROOM_CODE, it) }
+            meetingToken?.let { putExtra(TOKEN, it) }
+            meetingPrebuiltOptions?.let { putExtra(ROOM_PREBUILT, it) }
         }
 
         val pendingIntent = PendingIntent.getActivity(

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -134,10 +134,6 @@ class MeetingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-//        val hmsPrebuiltOption1: HMSPrebuiltOptions? =
-//            intent!!.extras!![ROOM_PREBUILT] as? HMSPrebuiltOptions
-//        Log.d("MeetingActivity", "onCreate called")
-//        Log.d("MeetingActivity", "options: $hmsPrebuiltOption1")
         _binding = ActivityMeetingBinding.inflate(layoutInflater)
         setContentView(binding.root)
         supportActionBar?.setDisplayShowTitleEnabled(false)
@@ -165,7 +161,7 @@ class MeetingActivity : AppCompatActivity() {
         callNotificationConfig = meetingPrebuiltOptions?.callNotificationConfig
 
         if (meetingRoomCode.isNullOrEmpty() && meetingToken.isNullOrEmpty()) {
-            Toast.makeText(this, "Session expired. Please rejoin the meeting.", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, "Room code or token is required", Toast.LENGTH_SHORT).show()
             finish()
             return
         }
@@ -214,7 +210,7 @@ class MeetingActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-         CallForegroundService.stop(this)
+        CallForegroundService.stop(this)
         _binding = null
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -215,7 +215,7 @@ class MeetingActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         // TEST: Commented out to test notification tap crash
-        // CallForegroundService.stop(this)
+         CallForegroundService.stop(this)
         _binding = null
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -214,7 +214,6 @@ class MeetingActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // TEST: Commented out to test notification tap crash
          CallForegroundService.stop(this)
         _binding = null
     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -1,6 +1,7 @@
 package live.hms.roomkit.ui.meeting
 
 import android.Manifest.permission.POST_NOTIFICATIONS
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.core.content.ContextCompat
@@ -70,6 +71,11 @@ class MeetingActivity : AppCompatActivity() {
     // Notification config from HMSPrebuiltOptions for foreground service
     private var callNotificationConfig: CallNotificationConfig? = null
 
+    // Meeting info for foreground service notification tap intent
+    private var meetingRoomCode: String? = null
+    private var meetingToken: String? = null
+    private var meetingPrebuiltOptions: HMSPrebuiltOptions? = null
+
     // Launcher for requesting notification permission on Android 13+
     private val notificationPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -105,7 +111,14 @@ class MeetingActivity : AppCompatActivity() {
         // Start service when user joins meeting (while app is still in foreground)
         if (isInActiveMeeting && !wasInActiveMeeting) {
             try {
-                CallForegroundService.start(this, callNotificationConfig, showDescription = false)
+                CallForegroundService.start(
+                    context = this,
+                    config = callNotificationConfig,
+                    showDescription = false,
+                    roomCode = meetingRoomCode,
+                    token = meetingToken,
+                    prebuiltOptions = meetingPrebuiltOptions
+                )
             } catch (e: Exception) {
                 Log.e("CallFGService", "Failed to start foreground service on join", e)
             }
@@ -121,6 +134,10 @@ class MeetingActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+//        val hmsPrebuiltOption1: HMSPrebuiltOptions? =
+//            intent!!.extras!![ROOM_PREBUILT] as? HMSPrebuiltOptions
+//        Log.d("MeetingActivity", "onCreate called")
+//        Log.d("MeetingActivity", "options: $hmsPrebuiltOption1")
         _binding = ActivityMeetingBinding.inflate(layoutInflater)
         setContentView(binding.root)
         supportActionBar?.setDisplayShowTitleEnabled(false)
@@ -139,23 +156,22 @@ class MeetingActivity : AppCompatActivity() {
         ViewCompat.setOnApplyWindowInsetsListener(binding.root, deferringInsetsListener)
 
 
-        val hmsPrebuiltOption: HMSPrebuiltOptions? =
-            intent!!.extras!![ROOM_PREBUILT] as? HMSPrebuiltOptions
+        // Extract meeting info from intent (null-safe to handle edge cases like notification tap)
+        meetingPrebuiltOptions = intent?.extras?.get(ROOM_PREBUILT) as? HMSPrebuiltOptions
+        meetingRoomCode = intent?.getStringExtra(ROOM_CODE) ?: ""
+        meetingToken = intent?.getStringExtra(TOKEN) ?: ""
 
         // Store notification config for foreground service
-        callNotificationConfig = hmsPrebuiltOption?.callNotificationConfig
+        callNotificationConfig = meetingPrebuiltOptions?.callNotificationConfig
 
-        val roomCode: String = intent?.getStringExtra(ROOM_CODE)?:""
-        val token: String = intent?.getStringExtra(TOKEN)?:""
-
-        if (roomCode.isEmpty() && token.isEmpty()) {
-            Toast.makeText(this, "Room code or token is required", Toast.LENGTH_SHORT).show()
+        if (meetingRoomCode.isNullOrEmpty() && meetingToken.isNullOrEmpty()) {
+            Toast.makeText(this, "Session expired. Please rejoin the meeting.", Toast.LENGTH_SHORT).show()
             finish()
+            return
         }
 
-
         binding.progressBar.visibility = View.VISIBLE
-        meetingViewModel.initSdk(roomCode, token, hmsPrebuiltOption, null)
+        meetingViewModel.initSdk(meetingRoomCode ?: "", meetingToken ?: "", meetingPrebuiltOptions, null)
 
         initObservers()
 
@@ -198,8 +214,8 @@ class MeetingActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        // Ensure service is stopped when activity is destroyed
-        CallForegroundService.stop(this)
+        // TEST: Commented out to test notification tap crash
+        // CallForegroundService.stop(this)
         _binding = null
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
@@ -355,22 +355,6 @@ class MeetingFragment : Fragment() {
         initObservers()
         initOnBackPress()
 
-        // TEST BUTTON - Remove after testing
-//        android.widget.Button(requireContext()).apply {
-//            text = "TEST: Kill Activity"
-//            setOnClickListener {
-//                // Finish activity without stopping the foreground service
-//                activity?.finishAndRemoveTask()
-//            }
-//            binding.meetingContainer.addView(this, RelativeLayout.LayoutParams(
-//                RelativeLayout.LayoutParams.WRAP_CONTENT,
-//                RelativeLayout.LayoutParams.WRAP_CONTENT
-//            ).apply {
-//                addRule(RelativeLayout.CENTER_HORIZONTAL)
-//                topMargin = 200
-//            })
-//        }
-
         meetingViewModel.countDownTimerStartedAt.observe(viewLifecycleOwner) { startedAt ->
             if (startedAt != null) {
                 binding.tvStreamingTime.visibility = View.VISIBLE

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
@@ -356,20 +356,20 @@ class MeetingFragment : Fragment() {
         initOnBackPress()
 
         // TEST BUTTON - Remove after testing
-        android.widget.Button(requireContext()).apply {
-            text = "TEST: Kill Activity"
-            setOnClickListener {
-                // Finish activity without stopping the foreground service
-                activity?.finishAndRemoveTask()
-            }
-            binding.meetingContainer.addView(this, RelativeLayout.LayoutParams(
-                RelativeLayout.LayoutParams.WRAP_CONTENT,
-                RelativeLayout.LayoutParams.WRAP_CONTENT
-            ).apply {
-                addRule(RelativeLayout.CENTER_HORIZONTAL)
-                topMargin = 200
-            })
-        }
+//        android.widget.Button(requireContext()).apply {
+//            text = "TEST: Kill Activity"
+//            setOnClickListener {
+//                // Finish activity without stopping the foreground service
+//                activity?.finishAndRemoveTask()
+//            }
+//            binding.meetingContainer.addView(this, RelativeLayout.LayoutParams(
+//                RelativeLayout.LayoutParams.WRAP_CONTENT,
+//                RelativeLayout.LayoutParams.WRAP_CONTENT
+//            ).apply {
+//                addRule(RelativeLayout.CENTER_HORIZONTAL)
+//                topMargin = 200
+//            })
+//        }
 
         meetingViewModel.countDownTimerStartedAt.observe(viewLifecycleOwner) { startedAt ->
             if (startedAt != null) {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
@@ -355,6 +355,22 @@ class MeetingFragment : Fragment() {
         initObservers()
         initOnBackPress()
 
+        // TEST BUTTON - Remove after testing
+        android.widget.Button(requireContext()).apply {
+            text = "TEST: Kill Activity"
+            setOnClickListener {
+                // Finish activity without stopping the foreground service
+                activity?.finishAndRemoveTask()
+            }
+            binding.meetingContainer.addView(this, RelativeLayout.LayoutParams(
+                RelativeLayout.LayoutParams.WRAP_CONTENT,
+                RelativeLayout.LayoutParams.WRAP_CONTENT
+            ).apply {
+                addRule(RelativeLayout.CENTER_HORIZONTAL)
+                topMargin = 200
+            })
+        }
+
         meetingViewModel.countDownTimerStartedAt.observe(viewLifecycleOwner) { startedAt ->
             if (startedAt != null) {
                 binding.tvStreamingTime.visibility = View.VISIBLE

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -1313,8 +1314,18 @@ class MeetingViewModel(
             }
 
             override fun onRemovedFromRoom(notification: HMSRemovedFromRoom) {
-                // Stop foreground service immediately - this callback runs even when app is in background
-                CallForegroundService.stop(getApplication())
+                // Check if app is in background (lifecycle not at least STARTED)
+                val isAppInBackground = !ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+
+                if (isAppInBackground) {
+                    // In background: LiveData observers are paused, so we need to explicitly stop
+                    CallForegroundService.stop(getApplication())
+
+                    // Stop HLS Player - must be on main thread (ExoPlayer requirement)
+                    viewModelScope.launch(Dispatchers.Main) {
+                        hmsPlayer?.stop()
+                    }
+                }
 
                 // Display a dialog that says they've been removed by X for Y with an ok button.
                 state.postValue(MeetingState.ForceLeave(notification))
@@ -2754,6 +2765,10 @@ class MeetingViewModel(
     var hmsPlayer : HmsHlsPlayer? = null
     fun setHLSPlayer(player: HmsHlsPlayer) {
         hmsPlayer = player
+    }
+
+    fun clearHLSPlayer() {
+        hmsPlayer = null
     }
 
     fun getHLSPLayer() = hmsPlayer

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -27,6 +27,7 @@ import live.hms.roomkit.HMSPluginScope
 import live.hms.roomkit.R
 import live.hms.roomkit.ui.HMSPrebuiltOptions
 import live.hms.roomkit.ui.meeting.activespeaker.ActiveSpeakerHandler
+import live.hms.roomkit.ui.meeting.CallForegroundService
 import live.hms.roomkit.ui.meeting.bottomsheets.StreamState
 import live.hms.roomkit.ui.meeting.chat.ChatMessage
 import live.hms.roomkit.ui.meeting.chat.Recipient
@@ -1312,6 +1313,9 @@ class MeetingViewModel(
             }
 
             override fun onRemovedFromRoom(notification: HMSRemovedFromRoom) {
+                // Stop foreground service immediately - this callback runs even when app is in background
+                CallForegroundService.stop(getApplication())
+
                 // Display a dialog that says they've been removed by X for Y with an ok button.
                 state.postValue(MeetingState.ForceLeave(notification))
             }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsFragment.kt
@@ -229,6 +229,9 @@ private const val MILLI_SECONDS_FROM_LIVE = 10_000
     @UnstableApi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        // Set HLS player reference in MeetingViewModel so it can be stopped from onRemovedFromRoom
+        meetingViewModel.setHLSPlayer(player)
+
         hlsViewModel.streamEndedEvent.observe(viewLifecycleOwner) {
             player.stop()
             StreamEnded.launch(parentFragmentManager)
@@ -468,6 +471,12 @@ private const val MILLI_SECONDS_FROM_LIVE = 10_000
 
     private fun openPolls() {
         findNavController().navigate(MeetingFragmentDirections.actionMeetingFragmentToPollsCreationFragment())
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        // Clear HLS player reference to avoid stale references when switching modes
+        meetingViewModel.clearHLSPlayer()
     }
 
     private fun statsObservers() {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsViewModel.kt
@@ -2,8 +2,11 @@ package live.hms.roomkit.ui.meeting.activespeaker
 
 import android.annotation.SuppressLint
 import android.app.Application
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
@@ -89,8 +92,16 @@ import live.hms.video.sdk.HMSSDK
                     hlsPlayerBeganToPlay(state)
                     isPlaying.postValue(true)
                 } else if (state == HmsHlsPlaybackState.stopped) {
-                    // Stop foreground service immediately - stream has ended
-                    CallForegroundService.stop(getApplication())
+                    // Check if app is in background (lifecycle not at least STARTED)
+                    val isAppInBackground = !ProcessLifecycleOwner.get().lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+
+                    if (isAppInBackground) {
+                        // In background: LiveData observers are paused, so we need to explicitly stop
+                        CallForegroundService.stop(getApplication())
+                        Log.d("HLSDEBUG", "Reached here, closing player")
+                        player.stop()
+                    }
+                    // In foreground: normal flow via streamEndedEvent observer will handle service/player stop
 
                     // Open end stream fragment.
                     hlsPlayerBeganToPlay(state)

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/activespeaker/HlsViewModel.kt
@@ -16,6 +16,7 @@ import live.hms.hls_player.HmsHlsException
 import live.hms.hls_player.HmsHlsPlaybackEvents
 import live.hms.hls_player.HmsHlsPlaybackState
 import live.hms.hls_player.HmsHlsPlayer
+import live.hms.roomkit.ui.meeting.CallForegroundService
 import live.hms.roomkit.util.SingleLiveEvent
 import live.hms.video.sdk.HMSSDK
 
@@ -88,6 +89,9 @@ import live.hms.video.sdk.HMSSDK
                     hlsPlayerBeganToPlay(state)
                     isPlaying.postValue(true)
                 } else if (state == HmsHlsPlaybackState.stopped) {
+                    // Stop foreground service immediately - stream has ended
+                    CallForegroundService.stop(getApplication())
+
                     // Open end stream fragment.
                     hlsPlayerBeganToPlay(state)
                     streamEndedEvent.postValue(Unit)


### PR DESCRIPTION
###  Summary                                                                                                                                                               
                                                                                                                                                                        
  - Fix crash when tapping foreground notification after MeetingActivity was destroyed                                                                                  
  - Fix notification persisting after call ends when app is in background                                                                                               
  - Fix HLS audio continuing to play after being removed from room in background                                                                                        
                                                                                                                                                                        
###  Changes                                                                                                                                                               
                                                                                                                                                                        
  - Pass meeting metadata (room code, token, prebuilt options) to CallForegroundService so MeetingActivity can be restored from notification tap                        
  - Stop foreground service and HLS player in onRemovedFromRoom and onPlaybackStateChanged(stopped) callbacks when app is in background                                 
  - Set HLS player reference early in HlsFragment.onViewCreated() and clear it in onDestroyView()  