### PR TITLE
Add local pinning and global spotlight for video tiles

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ kotlin.code.style=official
 100MS_APP_VERSION_NAME=5.0.17
 hmsRoomKitGroup=live.100ms
 HMS_ROOM_KIT_VERSION=1.3.7
-HMS_SDK_VERSION=2.9.79
+HMS_SDK_VERSION=2.9.80
 # Common publishing info
 publishing_licence_name="MIT License"
 publishing_licence_url="http://www.opensource.org/licenses/mit-license.php"

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ kotlin.code.style=official
 100MS_APP_VERSION_CODE=382
 100MS_APP_VERSION_NAME=5.0.17
 hmsRoomKitGroup=live.100ms
-HMS_ROOM_KIT_VERSION=1.3.7
+HMS_ROOM_KIT_VERSION=1.3.8
 HMS_SDK_VERSION=2.9.80
 # Common publishing info
 publishing_licence_name="MIT License"

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingActivity.kt
@@ -224,8 +224,7 @@ class MeetingActivity : AppCompatActivity() {
             invalidateOptionsMenu()
         }
         meetingViewModel.pinnedTrack.observe(this) {
-            if (it != null) Toast.makeText(this, "Spotlight: ${it.peer.name}", Toast.LENGTH_SHORT)
-                .show()
+            // Keeping this block for any op in future
         }
 
         meetingViewModel.hmsNotificationEvent.observe(this) { notification ->

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
@@ -558,14 +558,11 @@ class MeetingFragment : Fragment() {
         // Auto-switch to pinned view when a global spotlight arrives
         meetingViewModel.pinnedTrack.observe(viewLifecycleOwner) { track ->
             if (track != null && meetingViewModel.meetingViewMode.value != MeetingViewMode.PINNED) {
-                meetingViewModel.preserveLocalVideoState()
                 meetingViewModel.setMeetingViewMode(MeetingViewMode.PINNED)
                 val peerName = track.peer?.name ?: "Someone"
                 Toast.makeText(requireContext(), "$peerName has been spotlighted", Toast.LENGTH_SHORT).show()
             } else if (track == null && meetingViewModel.meetingViewMode.value == MeetingViewMode.PINNED) {
-                meetingViewModel.preserveLocalVideoState()
                 meetingViewModel.setMeetingViewMode(MeetingViewMode.GRID)
-                Toast.makeText(requireContext(), "Spotlight has been removed", Toast.LENGTH_SHORT).show()
             }
         }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
@@ -558,9 +558,14 @@ class MeetingFragment : Fragment() {
         // Auto-switch to pinned view when a global spotlight arrives
         meetingViewModel.pinnedTrack.observe(viewLifecycleOwner) { track ->
             if (track != null && meetingViewModel.meetingViewMode.value != MeetingViewMode.PINNED) {
+                meetingViewModel.preserveLocalVideoState()
                 meetingViewModel.setMeetingViewMode(MeetingViewMode.PINNED)
+                val peerName = track.peer?.name ?: "Someone"
+                Toast.makeText(requireContext(), "$peerName has been spotlighted", Toast.LENGTH_SHORT).show()
             } else if (track == null && meetingViewModel.meetingViewMode.value == MeetingViewMode.PINNED) {
+                meetingViewModel.preserveLocalVideoState()
                 meetingViewModel.setMeetingViewMode(MeetingViewMode.GRID)
+                Toast.makeText(requireContext(), "Spotlight has been removed", Toast.LENGTH_SHORT).show()
             }
         }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
@@ -555,6 +555,15 @@ class MeetingFragment : Fragment() {
             requireActivity().invalidateOptionsMenu()
         }
 
+        // Auto-switch to pinned view when a global spotlight arrives
+        meetingViewModel.pinnedTrack.observe(viewLifecycleOwner) { track ->
+            if (track != null && meetingViewModel.meetingViewMode.value != MeetingViewMode.PINNED) {
+                meetingViewModel.setMeetingViewMode(MeetingViewMode.PINNED)
+            } else if (track == null && meetingViewModel.meetingViewMode.value == MeetingViewMode.PINNED) {
+                meetingViewModel.setMeetingViewMode(MeetingViewMode.GRID)
+            }
+        }
+
         chatViewModel.unreadMessagesCount.observe(viewLifecycleOwner) { count ->
             if(meetingViewModel.prebuiltInfoContainer.isChatEnabled()) {
                 if (count > 0) {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingFragment.kt
@@ -24,6 +24,7 @@ import android.widget.RelativeLayout
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -1456,7 +1457,7 @@ class MeetingFragment : Fragment() {
             kotlin.runCatching { meetingViewModel.stopCurrentWhiteBoardSession() }
             //no permission required directly start screen share
             if (meetingViewModel.preRequestingPermissionForScreenShare().not())
-            startScreenShare()
+                startScreenShare()
         }
     }
 
@@ -1472,6 +1473,7 @@ class MeetingFragment : Fragment() {
     }
 
     //entry point to start PIP mode
+    @RequiresApi(Build.VERSION_CODES.N)
     private fun launchPipMode() {
 
         activity?.enterPictureInPictureMode()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -834,6 +834,14 @@ class MeetingViewModel(
 
     fun isLocalVideoEnabled(): Boolean? = hmsSDK.getLocalPeer()?.videoTrack?.isMute?.not()
 
+    // Saved video state to restore after fragment transitions that cause SDK auto-mute
+    // (all sinks removed when grid is destroyed → SDK auto-mutes → TRACK_MUTED intercepts and restores)
+    private var savedLocalVideoEnabled: Boolean? = null
+
+    fun preserveLocalVideoState() {
+        savedLocalVideoEnabled = isLocalVideoEnabled()
+    }
+
     fun toggleLocalVideo() {
         hmsSDK.getLocalPeer()?.videoTrack?.let {
             setLocalVideoEnabled(it.isMute)
@@ -1283,7 +1291,14 @@ class MeetingViewModel(
                             if (track.type == HMSTrackType.AUDIO)
                                 isLocalAudioEnabled.postValue(peer.audioTrack?.isMute != true)
                             else if (track.type == HMSTrackType.VIDEO) {
-                                isLocalVideoEnabled.postValue(peer.videoTrack?.isMute != true)
+                                // If the SDK auto-muted during a fragment transition (pin/unpin),
+                                // restore the previous state instead of accepting the mute
+                                if (savedLocalVideoEnabled == true) {
+                                    savedLocalVideoEnabled = null
+                                    setLocalVideoEnabled(true)
+                                } else {
+                                    isLocalVideoEnabled.postValue(peer.videoTrack?.isMute != true)
+                                }
                             }
                         }
                     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -834,14 +834,6 @@ class MeetingViewModel(
 
     fun isLocalVideoEnabled(): Boolean? = hmsSDK.getLocalPeer()?.videoTrack?.isMute?.not()
 
-    // Saved video state to restore after fragment transitions that cause SDK auto-mute
-    // (all sinks removed when grid is destroyed → SDK auto-mutes → TRACK_MUTED intercepts and restores)
-    private var savedLocalVideoEnabled: Boolean? = null
-
-    fun preserveLocalVideoState() {
-        savedLocalVideoEnabled = isLocalVideoEnabled()
-    }
-
     fun toggleLocalVideo() {
         hmsSDK.getLocalPeer()?.videoTrack?.let {
             setLocalVideoEnabled(it.isMute)
@@ -1291,15 +1283,7 @@ class MeetingViewModel(
                             if (track.type == HMSTrackType.AUDIO)
                                 isLocalAudioEnabled.postValue(peer.audioTrack?.isMute != true)
                             else if (track.type == HMSTrackType.VIDEO) {
-                                // If the SDK auto-muted during a fragment transition (pin/unpin),
-                                // restore the previous state instead of accepting the mute
-                                if (savedLocalVideoEnabled == true) {
-                                    savedLocalVideoEnabled = null
-                                    setLocalVideoEnabled(true)
-                                } else {
-                                    savedLocalVideoEnabled = null
-                                    isLocalVideoEnabled.postValue(peer.videoTrack?.isMute != true)
-                                }
+                                isLocalVideoEnabled.postValue(peer.videoTrack?.isMute != true)
                             }
                         }
                     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -1297,6 +1297,7 @@ class MeetingViewModel(
                                     savedLocalVideoEnabled = null
                                     setLocalVideoEnabled(true)
                                 } else {
+                                    savedLocalVideoEnabled = null
                                     isLocalVideoEnabled.postValue(peer.videoTrack?.isMute != true)
                                 }
                             }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/MeetingViewModel.kt
@@ -553,6 +553,30 @@ class MeetingViewModel(
         }
     }
 
+    fun spotlightTrack(trackId: String) {
+        if (!::pinnedTrackUseCase.isInitialized) return
+        pinnedTrackUseCase.updatePinnedTrack(trackId, object : HMSActionResultListener {
+            override fun onSuccess() {
+                Log.d(TAG, "Spotlight set for trackId: $trackId")
+            }
+            override fun onError(error: HMSException) {
+                Log.e(TAG, "Failed to set spotlight: ${error.message}")
+            }
+        })
+    }
+
+    fun removeSpotlight() {
+        if (!::pinnedTrackUseCase.isInitialized) return
+        pinnedTrackUseCase.updatePinnedTrack(null, object : HMSActionResultListener {
+            override fun onSuccess() {
+                Log.d(TAG, "Spotlight removed")
+            }
+            override fun onError(error: HMSException) {
+                Log.e(TAG, "Failed to remove spotlight: ${error.message}")
+            }
+        })
+    }
+
     fun isAutoSimulcastEnabled() = settings.disableAutoSimulcast
 
     fun isGoLiveInPreBuiltEnabled() = settings.enableVideoFilter
@@ -1758,6 +1782,10 @@ class MeetingViewModel(
     fun getAvailableRoles(): List<HMSRole> = hmsSDK.getRoles()
 
     fun isAllowedToChangeRole(): Boolean {
+        return hmsSDK.getLocalPeer()?.hmsRole?.permission?.changeRole == true
+    }
+
+    fun isAllowedToSpotlight(): Boolean {
         return hmsSDK.getLocalPeer()?.hmsRole?.permission?.changeRole == true
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/PinnedTrackUiUseCase.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/PinnedTrackUiUseCase.kt
@@ -8,8 +8,10 @@ import androidx.lifecycle.MediatorLiveData
  * The purpose of this mediator livedata is to show global pinned tracks before local ones.
  * Locally pinned tracks will only be shown if the global one isn't present.
  */
-class PinnedTrackUiUseCase(local : LiveData<MeetingTrack?>,
-global : LiveData<MeetingTrack?>) : MediatorLiveData<MeetingTrack?>() {
+class PinnedTrackUiUseCase(
+    local : LiveData<MeetingTrack?>,
+    global : LiveData<MeetingTrack?>
+) : MediatorLiveData<MeetingTrack?>() {
     private val TAG = "PinnedTrackUIUseCase"
     var isLocalTrackPinned = false
         private set

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -199,7 +199,8 @@ abstract class VideoGridBaseFragment : Fragment() {
         view.addTrack(track)
         view.disableAutoSimulcastLayerSelect(meetingViewModel.isAutoSimulcastEnabled())
         if (item.video?.isDegraded == true ) binding.hmsVideoView.hide() else binding.hmsVideoView.show()
-        binding.hmsVideoView.setOnClickListener {
+        // Use single click to prevent double-tap triggering two fragment transitions
+        binding.hmsVideoView.setOnSingleClickListener {
           meetingViewModel.preserveLocalVideoState()
           meetingViewModel.localPinnedTrack.postValue(item)
           meetingViewModel.setMeetingViewMode(MeetingViewMode.PINNED)

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -226,7 +226,10 @@ abstract class VideoGridBaseFragment : Fragment() {
         isLocalTrack = videoTrack is HMSLocalVideoTrack,
         onScreenCapture = { captureVideoFrame(surfaceView, videoTrack) },
         onSimulcast = { context.showSimulcastDialog(videoTrack as? HMSRemoteVideoTrack) },
-        onMirror = { context.showMirrorOptions(surfaceView)}
+        onMirror = { context.showMirrorOptions(surfaceView)},
+        onSpotlight = if (meetingViewModel.isAllowedToSpotlight() && videoTrack?.trackId != null) {
+          { meetingViewModel.spotlightTrack(videoTrack.trackId) }
+        } else null
       )
     }
   }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -21,6 +21,7 @@ import live.hms.roomkit.hide
 import live.hms.roomkit.show
 import live.hms.roomkit.ui.meeting.CustomPeerMetadata
 import live.hms.roomkit.ui.meeting.MeetingTrack
+import live.hms.roomkit.ui.meeting.MeetingViewMode
 import live.hms.roomkit.ui.meeting.MeetingViewModel
 import live.hms.roomkit.ui.meeting.pinnedvideo.StatsInterpreter
 import live.hms.roomkit.ui.settings.SettingsStore
@@ -198,6 +199,10 @@ abstract class VideoGridBaseFragment : Fragment() {
         view.addTrack(track)
         view.disableAutoSimulcastLayerSelect(meetingViewModel.isAutoSimulcastEnabled())
         if (item.video?.isDegraded == true ) binding.hmsVideoView.hide() else binding.hmsVideoView.show()
+        binding.hmsVideoView.setOnClickListener {
+          meetingViewModel.localPinnedTrack.postValue(item)
+          meetingViewModel.setMeetingViewMode(MeetingViewMode.PINNED)
+        }
         binding.hmsVideoView.setOnLongClickListener {
           (it as? HMSVideoView)?.let { videoView -> openDialog(videoView, item.video, item.peer.name.orEmpty()) }
           true

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -200,6 +200,7 @@ abstract class VideoGridBaseFragment : Fragment() {
         view.disableAutoSimulcastLayerSelect(meetingViewModel.isAutoSimulcastEnabled())
         if (item.video?.isDegraded == true ) binding.hmsVideoView.hide() else binding.hmsVideoView.show()
         binding.hmsVideoView.setOnClickListener {
+          meetingViewModel.preserveLocalVideoState()
           meetingViewModel.localPinnedTrack.postValue(item)
           meetingViewModel.setMeetingViewMode(MeetingViewMode.PINNED)
         }
@@ -227,6 +228,7 @@ abstract class VideoGridBaseFragment : Fragment() {
         onScreenCapture = { captureVideoFrame(surfaceView, videoTrack) },
         onSimulcast = { context.showSimulcastDialog(videoTrack as? HMSRemoteVideoTrack) },
         onMirror = { context.showMirrorOptions(surfaceView)},
+        peerName = peerName,
         onSpotlight = if (meetingViewModel.isAllowedToSpotlight() && videoTrack?.trackId != null) {
           { meetingViewModel.spotlightTrack(videoTrack.trackId) }
         } else null

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -201,7 +201,6 @@ abstract class VideoGridBaseFragment : Fragment() {
         if (item.video?.isDegraded == true ) binding.hmsVideoView.hide() else binding.hmsVideoView.show()
         // Use single click to prevent double-tap triggering two fragment transitions
         binding.hmsVideoView.setOnSingleClickListener {
-          meetingViewModel.preserveLocalVideoState()
           meetingViewModel.localPinnedTrack.postValue(item)
           meetingViewModel.setMeetingViewMode(MeetingViewMode.PINNED)
         }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
@@ -24,6 +24,7 @@ import live.hms.roomkit.util.*
 import live.hms.video.sdk.models.enums.HMSPeerUpdate
 import live.hms.videoview.HMSVideoView
 import hms.webrtc.RendererCommon
+import androidx.core.graphics.toColorInt
 
 class PinnedVideoFragment : Fragment() {
 
@@ -115,10 +116,14 @@ class PinnedVideoFragment : Fragment() {
       disableAutoSimulcastLayerSelect(meetingViewModel.isAutoSimulcastEnabled())
     }
 
-    // Repurpose the maximize button as a "back to grid" button
+    // Repurpose the maximize button as an unpin/close button
     binding.pinVideo.iconMaximised.apply {
-      setImageResource(R.drawable.ic_grid_view_24)
+      setImageResource(R.drawable.ic_cross)
       alpha = 1f
+      background = android.graphics.drawable.GradientDrawable().apply {
+        shape = android.graphics.drawable.GradientDrawable.OVAL
+        setColor("#2D3440".toColorInt())
+      }
       setOnClickListener { unpinAndGoBack() }
     }
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
@@ -54,6 +54,8 @@ class PinnedVideoFragment : Fragment() {
   // Determined using the onResume() and onPause()
   private var isViewVisible = false
 
+  private var wasLocalVideoOn: Boolean? = null
+
   override fun onResume() {
     super.onResume()
     Log.d(TAG, "onResume()")
@@ -62,6 +64,11 @@ class PinnedVideoFragment : Fragment() {
     handleOnPinVideoVisibilityChange()
 
     binding.recyclerViewVideos.adapter = videoListAdapter
+
+    // Restore camera state when returning from background
+    if (wasLocalVideoOn == true) {
+      meetingViewModel.setLocalVideoEnabled(true)
+    }
   }
 
   override fun onPause() {
@@ -70,6 +77,12 @@ class PinnedVideoFragment : Fragment() {
 
     isViewVisible = false
     handleOnPinVideoVisibilityChange()
+
+    // Mute camera on background to save battery, but not when switching view modes
+    wasLocalVideoOn = meetingViewModel.isLocalVideoEnabled() == true
+    if (wasLocalVideoOn == true && meetingViewModel.meetingViewMode.value == MeetingViewMode.PINNED) {
+      meetingViewModel.setLocalVideoEnabled(false)
+    }
 
     // Detaching the recycler view adapter calls [RecyclerView.Adapter::onViewDetachedFromWindow]
     // which performs the required cleanup of the ViewHolder (Releases SurfaceViewRenderer Egl.Context)
@@ -95,7 +108,6 @@ class PinnedVideoFragment : Fragment() {
     if (meetingViewModel.pinnedTrack.value != null) {
       meetingViewModel.removeSpotlight()
     }
-    meetingViewModel.preserveLocalVideoState()
     meetingViewModel.localPinnedTrack.postValue(null)
     meetingViewModel.setMeetingViewMode(MeetingViewMode.GRID)
   }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
@@ -7,13 +7,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.MainThread
+import androidx.appcompat.app.AlertDialog
 import androidx.core.view.forEach
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.recyclerview.widget.LinearLayoutManager
+import live.hms.roomkit.R
 import live.hms.roomkit.databinding.FragmentPinnedVideoBinding
 import live.hms.roomkit.ui.meeting.CustomPeerMetadata
 import live.hms.roomkit.ui.meeting.MeetingTrack
+import live.hms.roomkit.ui.meeting.MeetingViewMode
 import live.hms.roomkit.ui.meeting.MeetingViewModel
 import live.hms.roomkit.ui.meeting.MeetingViewModelFactory
 import live.hms.roomkit.ui.settings.SettingsStore
@@ -86,10 +89,38 @@ class PinnedVideoFragment : Fragment() {
     return binding.root
   }
 
+  private fun unpinAndGoBack() {
+    meetingViewModel.localPinnedTrack.postValue(null)
+    meetingViewModel.setMeetingViewMode(MeetingViewMode.GRID)
+  }
+
+  private fun showUnpinConfirmDialog() {
+    val peerName = pinnedTrack?.peer?.name ?: return
+    AlertDialog.Builder(requireContext())
+      .setTitle("Unpin")
+      .setMessage("Unpin $peerName and return to grid view?")
+      .setPositiveButton("Unpin") { _, _ -> unpinAndGoBack() }
+      .setNegativeButton("Cancel", null)
+      .show()
+  }
+
   private fun initPinnedView() {
     binding.pinVideo.hmsVideoView.apply {
       setScalingType(RendererCommon.ScalingType.SCALE_ASPECT_FIT)
       disableAutoSimulcastLayerSelect(meetingViewModel.isAutoSimulcastEnabled())
+    }
+
+    // Repurpose the maximize button as a "back to grid" button
+    binding.pinVideo.iconMaximised.apply {
+      setImageResource(R.drawable.ic_grid_view_24)
+      alpha = 1f
+      visibility = View.VISIBLE
+      setOnClickListener { unpinAndGoBack() }
+    }
+
+    // Tap pinned video to unpin with confirmation
+    binding.pinVideo.surfaceViewHolder.setOnClickListener {
+      showUnpinConfirmDialog()
     }
 
     updatePinnedVideoText()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
@@ -90,6 +90,10 @@ class PinnedVideoFragment : Fragment() {
   }
 
   private fun unpinAndGoBack() {
+    // If the current pin is a global spotlight, clear it for all peers
+    if (!meetingViewModel.pinnedTrackUiUseCase.isLocalTrackPinned) {
+      meetingViewModel.removeSpotlight()
+    }
     meetingViewModel.localPinnedTrack.postValue(null)
     meetingViewModel.setMeetingViewMode(MeetingViewMode.GRID)
   }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
@@ -91,7 +91,7 @@ class PinnedVideoFragment : Fragment() {
 
   private fun unpinAndGoBack() {
     // If the current pin is a global spotlight, clear it for all peers
-    if (!meetingViewModel.pinnedTrackUiUseCase.isLocalTrackPinned) {
+    if (meetingViewModel.pinnedTrack.value != null) {
       meetingViewModel.removeSpotlight()
     }
     meetingViewModel.localPinnedTrack.postValue(null)
@@ -101,8 +101,8 @@ class PinnedVideoFragment : Fragment() {
   private fun showUnpinConfirmDialog() {
     val peerName = pinnedTrack?.peer?.name ?: return
     AlertDialog.Builder(requireContext())
-      .setTitle("Unpin")
-      .setMessage("Unpin $peerName and return to grid view?")
+      .setTitle("Unpin this user?")
+      .setMessage("Unpin \"$peerName\" and return to grid view?")
       .setPositiveButton("Unpin") { _, _ -> unpinAndGoBack() }
       .setNegativeButton("Cancel", null)
       .show()
@@ -118,13 +118,20 @@ class PinnedVideoFragment : Fragment() {
     binding.pinVideo.iconMaximised.apply {
       setImageResource(R.drawable.ic_grid_view_24)
       alpha = 1f
-      visibility = View.VISIBLE
       setOnClickListener { unpinAndGoBack() }
     }
 
     // Tap pinned video to unpin with confirmation
     binding.pinVideo.surfaceViewHolder.setOnClickListener {
       showUnpinConfirmDialog()
+    }
+
+    // Reactively show/hide unpin controls based on global spotlight state
+    meetingViewModel.pinnedTrack.observe(viewLifecycleOwner) { globalTrack ->
+      val isGlobalSpotlight = globalTrack != null
+      val canUnpin = !isGlobalSpotlight || meetingViewModel.isAllowedToSpotlight()
+      binding.pinVideo.iconMaximised.visibility = if (canUnpin) View.VISIBLE else View.GONE
+      binding.pinVideo.surfaceViewHolder.isClickable = canUnpin
     }
 
     updatePinnedVideoText()

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
@@ -94,6 +94,7 @@ class PinnedVideoFragment : Fragment() {
     if (meetingViewModel.pinnedTrack.value != null) {
       meetingViewModel.removeSpotlight()
     }
+    meetingViewModel.preserveLocalVideoState()
     meetingViewModel.localPinnedTrack.postValue(null)
     meetingViewModel.setMeetingViewMode(MeetingViewMode.GRID)
   }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/pinnedvideo/PinnedVideoFragment.kt
@@ -179,9 +179,6 @@ class PinnedVideoFragment : Fragment() {
   private fun changePinViewVideo(track: MeetingTrack) {
     binding.pinVideo.iconAudioOff.visibility = visibility(track.peer.audioTrack?.isMute == true)
 
-
-
-    binding.pinVideo.iconAudioOff.visibility = visibility(track.peer.audioTrack?.isMute == true)
     if (track == pinnedTrack) {
       return
     }

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridFragment.kt
@@ -30,6 +30,7 @@ import live.hms.roomkit.ui.inset.makeInset
 import live.hms.roomkit.ui.meeting.ChangeNameDialogFragment
 import live.hms.roomkit.ui.meeting.CustomPeerMetadata
 import live.hms.roomkit.ui.meeting.MeetingTrack
+import live.hms.roomkit.ui.meeting.MeetingViewMode
 import live.hms.roomkit.ui.meeting.MeetingViewModel
 import live.hms.roomkit.ui.settings.SettingsStore
 import live.hms.roomkit.ui.theme.applyTheme
@@ -160,8 +161,12 @@ class VideoGridFragment : Fragment() {
         if (localMeeting == null) return
         wasLocalVideoTrackVideoOn = (localMeeting?.video?.isMute?:true) == false
         updateVideoViewLayout(binding.insetPillMaximised, isVideoOff = true, localMeeting)
-        meetingViewModel.setLocalVideoEnabled(false)
-        lastVideoMuteState = true
+        // Only mute camera if we're actually going to background, not switching view modes.
+        // When switching (e.g. GRID → PINNED), meetingViewMode is already updated before onPause fires.
+        if (meetingViewModel.meetingViewMode.value == MeetingViewMode.GRID) {
+            meetingViewModel.setLocalVideoEnabled(false)
+            lastVideoMuteState = true
+        }
     }
 
     override fun onResume() {

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridFragment.kt
@@ -175,7 +175,7 @@ class VideoGridFragment : Fragment() {
         if (wasLocalVideoTrackVideoOn == true) {
             meetingViewModel.setLocalVideoEnabled(true)
             if (isMinimized.not())
-            updateVideoViewLayout(binding.insetPillMaximised, isVideoOff = false, localMeeting)
+                updateVideoViewLayout(binding.insetPillMaximised, isVideoOff = false, localMeeting)
             lastVideoMuteState = false
         }
     }

--- a/room-kit/src/main/java/live/hms/roomkit/util/ViewExt.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/util/ViewExt.kt
@@ -117,22 +117,24 @@ fun Context.showTileListDialog(
   onScreenCapture: (() -> Unit),
   onSimulcast: (() -> Unit),
   onMirror: (() -> Unit),
+  peerName: String? = null,
   onSpotlight: (() -> Unit)? = null
 ) {
 
   val builder = AlertDialog.Builder(this)
   builder.setTitle("Perform Action")
+  val spotlightLabel = if (peerName != null) "Spotlight \"$peerName\" for everyone" else "Spotlight for everyone"
   val intentList = mutableListOf("Screen Capture", "Mirror")
   if (isLocalTrack.not())
     intentList+= "Simulcast"
   if (onSpotlight != null)
-    intentList+= "Spotlight for everyone"
+    intentList+= spotlightLabel
   builder.setItems(intentList.toTypedArray()) { _, which ->
     when (intentList[which]) {
       "Screen Capture" -> onScreenCapture.invoke()
       "Mirror" -> onMirror()
       "Simulcast" -> onSimulcast.invoke()
-      "Spotlight for everyone" -> onSpotlight?.invoke()
+      spotlightLabel -> onSpotlight?.invoke()
     }
   }
 

--- a/room-kit/src/main/java/live/hms/roomkit/util/ViewExt.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/util/ViewExt.kt
@@ -116,7 +116,8 @@ fun Context.showTileListDialog(
   isLocalTrack : Boolean,
   onScreenCapture: (() -> Unit),
   onSimulcast: (() -> Unit),
-  onMirror: (() -> Unit)
+  onMirror: (() -> Unit),
+  onSpotlight: (() -> Unit)? = null
 ) {
 
   val builder = AlertDialog.Builder(this)
@@ -124,13 +125,14 @@ fun Context.showTileListDialog(
   val intentList = mutableListOf("Screen Capture", "Mirror")
   if (isLocalTrack.not())
     intentList+= "Simulcast"
+  if (onSpotlight != null)
+    intentList+= "Spotlight for everyone"
   builder.setItems(intentList.toTypedArray()) { _, which ->
-    when (which) {
-      0 -> { onScreenCapture.invoke() }
-        1 -> {onMirror()}
-      2 -> {
-          onSimulcast.invoke()
-      }
+    when (intentList[which]) {
+      "Screen Capture" -> onScreenCapture.invoke()
+      "Mirror" -> onMirror()
+      "Simulcast" -> onSimulcast.invoke()
+      "Spotlight for everyone" -> onSpotlight?.invoke()
     }
   }
 


### PR DESCRIPTION
 ### Summary

  - Tap-to-pin: Tapping a video tile in the grid view locally pins it, switching to the pinned (hero) view. Uses setOnSingleClickListener to prevent double-tap issues.
  - Global spotlight: Long-pressing a video tile shows a "Spotlight [peer name] for everyone" option (host-only, gated by changeRole permission) that writes to HMS
  Session Store, syncing the spotlight across all peers.
  - Unpin/remove spotlight: Pinned view has a close (X) button and tap-to-unpin with confirmation dialog. For global spotlights, non-host peers cannot unpin — the
  button is reactively hidden based on spotlight state.
  - Auto-switch on spotlight: All peers auto-switch to pinned view when a spotlight arrives and back to grid when it's removed, with a toast notification.
  - Camera mute fix: Prevent local camera from being muted during view mode transitions (GRID ↔ PINNED). VideoGridFragment.onPause() and PinnedVideoFragment.onPause()
  now skip muting when switching modes, only muting on actual background events.

  **Files changed**

  - VideoGridBaseFragment.kt — tap-to-pin click listener, spotlight option in long-press dialog
  - PinnedVideoFragment.kt — unpin/close button (X icon, circular bg), confirm dialog, reactive host-gating, background camera mute
  - MeetingViewModel.kt — spotlightTrack(), removeSpotlight(), isAllowedToSpotlight()
  - MeetingFragment.kt — global spotlight observer for auto mode switching + toast
  - VideoGridFragment.kt — skip camera mute on mode switch in onPause()
  - ViewExt.kt — spotlight option with peer name in tile dialog, string-based action matching
  - PinnedTrackUiUseCase.kt — formatting cleanup
  - MeetingActivity.kt — removed old spotlight toast (moved to MeetingFragment)