### PR TITLE
Update HMS Room Kit and SDK versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,8 @@ kotlin.code.style=official
 100MS_APP_VERSION_CODE=382
 100MS_APP_VERSION_NAME=5.0.17
 hmsRoomKitGroup=live.100ms
-HMS_ROOM_KIT_VERSION=1.3.8
-HMS_SDK_VERSION=2.9.80
+HMS_ROOM_KIT_VERSION=1.3.9
+HMS_SDK_VERSION=2.9.81
 # Common publishing info
 publishing_licence_name="MIT License"
 publishing_licence_url="http://www.opensource.org/licenses/mit-license.php"


### PR DESCRIPTION
This commit bumps `HMS_ROOM_KIT_VERSION` to 1.3.9 and `HMS_SDK_VERSION` to 2.9.81 in `gradle.properties`.
The latest HMS_SDK_VERSION (2.9.81) has the fix for the telephony callback crash.