### PR TITLE
chore: API 35 app migration, SFU remote-track fix, and SDK bump to 2.9.84

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ app/gradle.properties
 .cxx
 local.properties
 *.aar
+*.jks
 assets/*.mp4
 secrets/
 room-kit/gradle.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,13 +7,24 @@ plugins {
     id 'com.google.firebase.crashlytics'
 }
 android {
-    compileSdk 34
+    compileSdk 35
     namespace = "live.hms.app2"
+
+    signingConfigs {
+        release {
+            def props = new Properties()
+            props.load(new FileInputStream(rootProject.file("local.properties")))
+            storeFile file('100ms-android.jks')
+            storePassword props['RELEASE_STORE_PASSWORD']
+            keyAlias props['RELEASE_KEY_ALIAS']
+            keyPassword props['RELEASE_KEY_PASSWORD']
+        }
+    }
 
     defaultConfig {
         applicationId "live.hms.app2"
         minSdkVersion 21
-        targetSdk 34
+        targetSdk 35
         versionCode project.findProperty('100MS_APP_VERSION_CODE') as int
         versionName project.findProperty('100MS_APP_VERSION_NAME')
 
@@ -31,6 +42,7 @@ android {
         }
 
         release {
+            signingConfig signingConfigs.release
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 
@@ -43,6 +55,12 @@ android {
     buildFeatures {
         viewBinding = true
         buildConfig = true
+    }
+
+    packagingOptions {
+        jniLibs {
+            useLegacyPackaging = true
+        }
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
@@ -61,7 +79,9 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     //100ms.live prebuilt lib
-    implementation "live.100ms:room-kit:$HMS_ROOM_KIT_VERSION"
+//    implementation "live.100ms:room-kit:$HMS_ROOM_KIT_VERSION"
+    implementation project(':room-kit')
+
 
     implementation "live.100ms:virtual-background:$HMS_SDK_VERSION"
     //100ms noise cancellation dep

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,8 +79,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     //100ms.live prebuilt lib
-//    implementation "live.100ms:room-kit:$HMS_ROOM_KIT_VERSION"
-    implementation project(':room-kit')
+    implementation "live.100ms:room-kit:$HMS_ROOM_KIT_VERSION"
 
 
     implementation "live.100ms:virtual-background:$HMS_SDK_VERSION"

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -32,3 +32,9 @@
 # Previously required proguard rules for sdk, now included in the library.
 #-keep class hms.webrtc.** { *; }
 #-keep class live.hms.video.** { *; }
+
+# MediaPipe / protobuf classes referenced transitively by virtual-background
+# but not needed at runtime on Android.
+-dontwarn com.google.mediapipe.framework.image.**
+-dontwarn com.google.mediapipe.proto.**
+-dontwarn com.google.protobuf.**

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-100MS_APP_VERSION_CODE=382
-100MS_APP_VERSION_NAME=5.0.17
+100MS_APP_VERSION_CODE=384
+100MS_APP_VERSION_NAME=5.0.18
 hmsRoomKitGroup=live.100ms
 HMS_ROOM_KIT_VERSION=1.3.9
 HMS_SDK_VERSION=2.9.81

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ kotlin.code.style=official
 100MS_APP_VERSION_NAME=5.0.18
 hmsRoomKitGroup=live.100ms
 HMS_ROOM_KIT_VERSION=1.3.9
-HMS_SDK_VERSION=2.9.81
+HMS_SDK_VERSION=2.9.84
 # Common publishing info
 publishing_licence_name="MIT License"
 publishing_licence_url="http://www.opensource.org/licenses/mit-license.php"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,3 +1,5 @@
 configurations.maybeCreate("default")
 artifacts.add("default", file('lib-debug.aar'))
 
+
+

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridPageFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridPageFragment.kt
@@ -104,7 +104,11 @@ class VideoGridPageFragment : VideoGridBaseFragment() {
 
     if (isScreenShare.not()) {
       meetingViewModel.speakerUpdateLiveData.observe(viewLifecycleOwner) { videoGridTrack ->
-        renderCurrentPage(videoGridTrack)
+        // isForceUpdate=true ensures bindSurfaceView runs even when isFragmentVisible
+        // hasn't been set to true yet (happens during SFU migration: pages count
+        // transiently drops to 0 → FragmentStateAdapter destroys + recreates this
+        // fragment → LiveData fires before onResume, leaving video tracks unattached).
+        renderCurrentPage(videoGridTrack, isForceUpdate = true)
       }
     } else {
       meetingViewModel.tracks.observe(viewLifecycleOwner) { track ->


### PR DESCRIPTION
Bundles three changes on this branch (relative to `release-v2`):

### 1. `chore: bump HMS android-sdk to 2.9.84`
Bumps `HMS_SDK_VERSION` `2.9.81 → 2.9.84`. Picks up the camera re-acquisition fix from `live.100ms/android-sdk` (100mslive/android-sdk#962, released as `2.9.84`): after the OS revokes the camera while the app is backgrounded, the SDK now restarts capture on foreground instead of leaving the local peer's video frozen/black for remote peers. Complements room-kit's own lifecycle mute/unmute as a safety net.

Note: this version is read straight from `gradle.properties` (the publish workflow only overrides `HMS_ROOM_KIT_VERSION`), so it is baked into room-kit's published POM as `implementation "live.100ms:android-sdk:2.9.84"`.

### 2. `fix(room-kit): bind remote video tracks after SFU migration`
Re-binds remote video tracks following an SFU migration so remote video continues rendering.

### 3. `Update Android SDK to version 35 and configure release signing`
API 35 target migration + release signing config (+ proguard rules).

### Release note
`HMS_ROOM_KIT_VERSION` is intentionally left at `1.3.9` — the room-kit publish workflow sets the published version from the release tag (`github.ref_name`), so the new room-kit version is chosen when the release is cut.