### PR TITLE
chore: bump HMS_ROOM_KIT_VERSION to 1.3.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ kotlin.code.style=official
 100MS_APP_VERSION_CODE=384
 100MS_APP_VERSION_NAME=5.0.18
 hmsRoomKitGroup=live.100ms
-HMS_ROOM_KIT_VERSION=1.3.9
+HMS_ROOM_KIT_VERSION=1.3.10
 HMS_SDK_VERSION=2.9.84
 # Common publishing info
 publishing_licence_name="MIT License"


### PR DESCRIPTION
Bumps `HMS_ROOM_KIT_VERSION` in `gradle.properties` from `1.3.9` to `1.3.10` so the app depends on the published room-kit `1.3.10`.

Note: this depends on `live.100ms:room-kit:1.3.10` being published to Maven Central (via the `roomkit-publish.yml` CI on a `1.3.10` GitHub Release). Merge alongside / after that publish so clean builds resolve the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)