### PR TITLE
fix(app): guard local.properties read in release signingConfig

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,12 +12,15 @@ android {
 
     signingConfigs {
         release {
-            def props = new Properties()
-            props.load(new FileInputStream(rootProject.file("local.properties")))
-            storeFile file('100ms-android.jks')
-            storePassword props['RELEASE_STORE_PASSWORD']
-            keyAlias props['RELEASE_KEY_ALIAS']
-            keyPassword props['RELEASE_KEY_PASSWORD']
+            def propsFile = rootProject.file("local.properties")
+            if (propsFile.exists()) {
+                def props = new Properties()
+                props.load(new FileInputStream(propsFile))
+                storeFile file('100ms-android.jks')
+                storePassword props['RELEASE_STORE_PASSWORD']
+                keyAlias props['RELEASE_KEY_ALIAS']
+                keyPassword props['RELEASE_KEY_PASSWORD']
+            }
         }
     }
 


### PR DESCRIPTION
## Problem
The room-kit publish CI (`Android CI` / `roomkit-publish.yml`) for `1.3.10` failed at the **Deploy to Maven Central** step:

```
A problem occurred evaluating project ':app'.
> .../local.properties (No such file or directory)
```

The `release` signingConfig added in `865d5dc7` reads `local.properties` **unconditionally** at configuration time. Gradle configures every project on any invocation, so even though the publish only targets the room-kit modules, evaluating `:app` throws `FileNotFoundException` on CI (no `local.properties`), failing the whole build before publishing. This is why 1.3.9 published fine but 1.3.10 didn't.

## Fix
Only load `local.properties` when it exists. CI never builds `:app`'s release variant, so it doesn't need the signing values; real release builds that provide the file are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)