### PR TITLE
fix(video-grid): scope forced bind to on-screen page to avoid EGL context exhaustion

### DIFF
--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/commons/VideoGridBaseFragment.kt
@@ -351,8 +351,12 @@ abstract class VideoGridBaseFragment : Fragment() {
         requiresGridLayoutUpdate = true
 
         layout.apply {
-          // Unbind only when view is visible to user
-          if (isFragmentVisible|| isForceUpdate) unbindSurfaceView(
+          // Always release the renderer (frees its EGL context) before dropping the tile.
+          // safeRelease() is guarded by isInitialised, so this is a no-op for a tile that never
+          // created a context. Gating this on visibility could orphan a live EGL context: the
+          // view is removed and dropped from renderedViews with nobody left to release it, which
+          // (now that binding is scoped to the selected page) leaks contexts toward the cap.
+          unbindSurfaceView(
             currentRenderedView.binding.videoCard,
             currentRenderedView.meetingTrack
           )

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridFragment.kt
@@ -539,8 +539,16 @@ class VideoGridFragment : Fragment() {
                 // Without this, the extra inset adds one more tile than they should
                 val expectedPages =
                     Math.ceil((onthePeerGridTileCount.toDouble() / itemsPerPage.toDouble())).toInt()
+                // Keep the selected-page trackers valid across adapter rebuilds. When the page
+                // count shrinks (e.g. SFU migration drops pages to 0 then rebuilds), ViewPager2
+                // clamps currentItem to 0 but does not reliably dispatch onPageSelected(0), which
+                // would leave the tracker stale and make the visible page-0 evaluate
+                // isSelectedPage()==false — reintroducing the transient black tile this fix
+                // prevents. Mirror the clamp: if the tracked index is now out of range, reset it.
+                if (currentScreenSharePage >= remoteScreenShareTilesCount) currentScreenSharePage = 0
                 screenShareAdapter.totalPages = remoteScreenShareTilesCount
                 meetingViewModel.transcriptionsPositionUseCase.setScreenShare(remoteScreenShareTilesCount + localScreenShareTileCount != 0)
+                if (currentPeerGridPage >= expectedPages) currentPeerGridPage = 0
                 peerGridVideoAdapter.totalPages = expectedPages
 
                 binding.tabLayoutDots.visibility =

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridFragment.kt
@@ -18,6 +18,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
+import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.tabs.TabLayoutMediator
 import live.hms.roomkit.R
 import live.hms.roomkit.databinding.FragmentGridVideoBinding
@@ -58,6 +59,19 @@ class VideoGridFragment : Fragment() {
 
     private lateinit var peerGridVideoAdapter: VideoGridAdapter
     private lateinit var screenShareAdapter: VideoGridAdapter
+
+    // Index of the page currently shown in each video pager. VideoGridPageFragment reads this
+    // to decide which page may create GPU renderers (EGL contexts): only the on-screen page
+    // does, so off-screen pages don't exhaust the device's EGL-context limit in large rooms.
+    var currentPeerGridPage: Int = 0
+        private set
+    var currentScreenSharePage: Int = 0
+        private set
+
+    /** Page index currently shown in the given pager (defaults to 0, incl. after a rebuild). */
+    fun currentSelectedPage(isScreenShare: Boolean): Int =
+        if (isScreenShare) currentScreenSharePage else currentPeerGridPage
+
     var isMinimized = false
     var whiteboardView : WebView? = null
     var lastVideoMuteState : Boolean? = null
@@ -191,6 +205,10 @@ class VideoGridFragment : Fragment() {
             offscreenPageLimit = 1
             adapter = this@VideoGridFragment.peerGridVideoAdapter
 
+            registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) { currentPeerGridPage = position }
+            })
+
             TabLayoutMediator(binding.tabLayoutDots, this) { _, _ ->
                 // No text to be shown
             }.attach()
@@ -199,6 +217,11 @@ class VideoGridFragment : Fragment() {
         binding.viewPagerRemoteScreenShare.apply {
             offscreenPageLimit = 1
             adapter = this@VideoGridFragment.screenShareAdapter
+
+            registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) { currentScreenSharePage = position }
+            })
+
             TabLayoutMediator(binding.tabLayoutDotsRemoteScreenShare, this) { _, _ ->
             }.attach()
 

--- a/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridPageFragment.kt
+++ b/room-kit/src/main/java/live/hms/roomkit/ui/meeting/videogrid/VideoGridPageFragment.kt
@@ -104,17 +104,20 @@ class VideoGridPageFragment : VideoGridBaseFragment() {
 
     if (isScreenShare.not()) {
       meetingViewModel.speakerUpdateLiveData.observe(viewLifecycleOwner) { videoGridTrack ->
-        // isForceUpdate=true ensures bindSurfaceView runs even when isFragmentVisible
-        // hasn't been set to true yet (happens during SFU migration: pages count
-        // transiently drops to 0 → FragmentStateAdapter destroys + recreates this
-        // fragment → LiveData fires before onResume, leaving video tracks unattached).
-        renderCurrentPage(videoGridTrack, isForceUpdate = true)
+        // Force a bind (which creates a GPU renderer / EGL context) ONLY for the page that is
+        // actually on screen. Off-screen neighbour pages skip it and bind lazily via
+        // onResume -> bindViews() when swiped to, so we don't hold several pages' worth of EGL
+        // contexts at once (that exhausts the device's context cap in large rooms and crashes
+        // with "Failed to create EGL context"). Forcing the *selected* page still fixes the
+        // SFU-migration recreate race, where the LiveData fires before onResume promotes the
+        // freshly-created visible fragment to RESUMED.
+        renderCurrentPage(videoGridTrack, isForceUpdate = isSelectedPage())
       }
     } else {
       meetingViewModel.tracks.observe(viewLifecycleOwner) { track ->
         synchronized(track) {
           val screenShareTrack = track.filter { it.isScreen  }.toList()
-          renderCurrentPage(screenShareTrack, isForceUpdate = true)
+          renderCurrentPage(screenShareTrack, isForceUpdate = isSelectedPage())
 
         }
       }
@@ -136,6 +139,13 @@ class VideoGridPageFragment : VideoGridBaseFragment() {
   override fun isScreenshare(): Boolean {
     return isScreenShare
   }
+
+  /**
+   * True when this page is the one currently shown in its pager. Only the on-screen page should
+   * create renderers/EGL contexts; off-screen pages bind lazily when they become visible.
+   */
+  private fun isSelectedPage(): Boolean =
+    (parentFragment as? VideoGridFragment)?.currentSelectedPage(isScreenShare) == pageIndex
 
   private fun renderCurrentPage(tracks: List<MeetingTrack>, isForceUpdate : Boolean = false) {
     val videos = getCurrentPageVideos(tracks)


### PR DESCRIPTION
## Problem
Crash on the video grid: `RuntimeException: android.opengl.GLException: Failed to create EGL context` (from `SurfaceViewRenderer.init` → `HMSVideoView.addTrack`). High volume for large-room customers on low/mid-end GPUs (e.g. Entri).

## Cause
Each video tile allocates its own **EGL context** (a capped GPU resource — commonly ~32 on low-end GPUs). RoomKit **1.3.10** changed the grid observers to bind unconditionally (`isForceUpdate = true`). With `offscreenPageLimit = 1`, three pager pages are alive, so the **off-screen** pages started creating contexts too — ~3× the live contexts. In large rooms this crosses the device cap and the next `eglCreateContext` fails → crash. (Latent before 1.3.10; the change amplified it.)

`isForceUpdate = true` was added to fix black tiles after an SFU migration (fragment recreated, LiveData delivers before `onResume`, bind gated out). That only ever mattered for the **on-screen** page.

## Fix
Scope the forced bind to the page actually on screen, so off-screen pages no longer hold contexts (they bind lazily on `onResume` when swiped to). Live contexts drop back to ~1 page's worth (pre-1.3.10 baseline); the migration fix is preserved for the visible page.

- **VideoGridFragment** — track the selected page per pager via `ViewPager2.OnPageChangeCallback`.
- **VideoGridPageFragment** — `isForceUpdate = isSelectedPage()` on both the speaker and screenshare observers.
- **VideoGridBaseFragment** — always release a removed tile's renderer (drop the visibility gate) so scoping the bind can't orphan a live context.

## Testing
- `:room-kit:compileDebugKotlin` passes.
- The GPU-cap crash reproduces only on genuinely low-cap devices, so verify on a low/mid-end handset in a multi-page room: swipe the grid + toggle screenshare, confirm no `GLException` and video still renders on the visible page.

## Note
SFU migration is not enabled on Android yet; when it is, verify the visible grid page re-renders after a migration (the scoped force still covers it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
